### PR TITLE
Disable device validation on mayastor-msp-operator

### DIFF
--- a/addons/mayastor/chart/values.yaml
+++ b/addons/mayastor/chart/values.yaml
@@ -56,15 +56,8 @@ mayastor-control-plane:
     node:
       image: cdkbot/mayastor-csi-node
   msp:
+    disableDeviceValidation: true
     image: cdkbot/mayastor-msp-operator
-    extraVolumes:
-      - name: data
-        hostPath:
-          path: /var/snap/microk8s/common/mayastor/data
-          type: DirectoryOrCreate
-    extraVolumeMounts:
-      - name: data
-        mountPath: /data
 
 # Mayastor configuration
 mayastor:


### PR DESCRIPTION
### Summary

Disable device validation instead of checking local hostpath for the file.