### PR TITLE
Upgrade hostpath-provisioner to 1.2.0

### DIFF
--- a/addons/hostpath-storage/storage.yaml
+++ b/addons/hostpath-storage/storage.yaml
@@ -19,16 +19,20 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner:1.1.0
+          image: cdkbot/hostpath-provisioner:1.2.0
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: PV_DIR
               value: $SNAP_COMMON/default-storage
-          #            - name: PV_RECLAIM_POLICY
-          #              value: Retain
+          #   - name: PV_RECLAIM_POLICY
+          #     value: Retain
           volumeMounts:
             - name: pv-volume
               mountPath: $SNAP_COMMON/default-storage
@@ -44,6 +48,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: microk8s.io/hostpath
+volumeBindingMode: WaitForFirstConsumer
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -97,6 +102,18 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Summary

Update hostpath-provisioner to use temporary busybox pods to provision volumes. This allows the provisioner to work correctly in multi-node MicroK8s clusters.

### Notes

Needs https://github.com/juju-solutions/hostpath-provisioner/pull/3
