### PR TITLE
Update etcd-operator image to include DNS resolution fixes

### DIFF
--- a/addons/mayastor/chart/values.yaml
+++ b/addons/mayastor/chart/values.yaml
@@ -6,6 +6,7 @@ rbac:
 # Configuration for etcd-operator chart
 etcd-operator:
   operator:
+    image: cdkbot/etcd-operator:0.10.0-microk8s-2
     enabled: true
   rbac:
     enabled: true


### PR DESCRIPTION
### Summary

Update etcd-operator image to include https://github.com/canonical/etcd-operator/commit/2c19720af76c912ca75b75bcd850c6ba267a5b4d

This is required since #6 has silently affected how DNS resolution works for not ready addreses.
