### PR TITLE
Delete image files when disabling mayastor by default

### DIFF
--- a/addons/mayastor/disable
+++ b/addons/mayastor/disable
@@ -16,8 +16,8 @@ MAYASTOR_DATA = pathlib.Path(os.path.expandvars("$SNAP_COMMON/mayastor/data"))
 
 
 @click.command()
-@click.option("--remove-storage", is_flag=True, default=False)
-@click.option("--force", is_flag=True, default=False)
+@click.option("--remove-storage/--preserve-storage", is_flag=True, default=True)
+@click.option("--force/--no-force", is_flag=True, default=True)
 def main(remove_storage: bool, force: bool):
     pools = subprocess.check_output(
         [KUBECTL, "get", "msp", "-n", "mayastor", "-o", "json"],

--- a/addons/mayastor/enable
+++ b/addons/mayastor/enable
@@ -11,6 +11,8 @@ import click
 
 DIR = pathlib.Path(__file__).parent.absolute()
 
+MAYASTOR_DATA = pathlib.Path(os.path.expandvars("$SNAP_COMMON/mayastor/data"))
+
 KUBECTL = os.path.expandvars("$SNAP/microk8s-kubectl.wrapper")
 HELM = os.path.expandvars("$SNAP/microk8s-helm3.wrapper")
 MICROK8S_STATUS = os.path.expandvars("$SNAP/microk8s-status.wrapper")
@@ -109,7 +111,6 @@ def main(
     # Create mayastor namespace. Ignore failures (e.g. if namespace exists)
     subprocess.run([KUBECTL, "create", "namespace", "mayastor"])
 
-
     args = ["-f", DIR / "chart/values.yaml"]
     if not create_storage_classes:
         click.echo("Storage classes will not be created, please configure manually")
@@ -120,6 +121,22 @@ def main(
 
     # Fetch dependencies
     subprocess.check_call([HELM, "dependency", "update"], cwd=DIR / "chart")
+
+    # If microk8s.img already exists, this is most likely from a previous installation
+    # Print a warning to the user.
+    microk8s_img = MAYASTOR_DATA / "microk8s.img"
+    if microk8s_img.exists():
+        click.echo(f"""
+============================================================
+
+WARNING: {microk8s_img} already exists.
+To prevent data loss, no pool will be created by default. To fix this, you
+can do a clean install of the mayastor addon with:
+
+    microk8s disable mayastor --remove-storage
+    microk8s enable mayastor
+
+""")
 
     # Install
     subprocess.check_call([HELM, "install", "mayastor", "-n", "mayastor", DIR / "chart", *args])
@@ -137,6 +154,7 @@ Mayastor will run for all nodes in your MicroK8s cluster by default. Use the
 
 """
     )
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Fixes #14

Do not preserve the mayastor image files by default when disabling the addon