### PR TITLE
Bump ingress version that fixes CVEs 

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -30,7 +30,7 @@ microk8s-addons:
 
     - name: "ingress"
       description: "Ingress controller for external access"
-      version: "1.1.0"
+      version: "1.2.0"
       check_status: "pod/nginx-ingress-microk8s-controller"
       supported_architectures:
         - arm64

--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -24,7 +24,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="v1.1.0"
+TAG="v1.2.0"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 


### PR DESCRIPTION
### Description

The [new version 1.2.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.2.0) of the ingress controller includes some security fixes. This PR bumps the version that will be used by the ingress microk8s addon.

#### Testing
In order to test it, I have done the following:
- Snapcraft build microk8s locally pointing to my forked repo with the 1.2.0 ingress version.
- Enable the ingress addon
```bash
$ microk8s enable ingress
```
- Check that indeed the right version was installed with:
```bash
$ microk8s kubectl get pods -n ingress -oyaml | grep -i image: | grep ingress
      image: k8s.gcr.io/ingress-nginx/controller:v1.2.0
```
- I check that it works by exposing a node port service:
```bash
$ microk8s kubectl create deployment server-gog -n ingress --image=nkolchenko/enea:server_go_latest
deployment.apps/server-gog created

$ microk8s kubectl expose -n ingress deployment server-gog --type=NodePort --port=8180 --selector=app=server-gog

$ microk8s kubectl get svc -o wide -n ingress server-gog
NAME         TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)          AGE   SELECTOR
server-gog   NodePort   10.152.183.254   <none>        8180:32068/TCP   76s   app=server-gog

# Checking that the app is avaliable at K8S_node_IP:32068 and 10.152.183.254:8180
$ curl K8S_node_IP:32068/some_string
Hello from ServerGo. You requested: /some_string

$ curl 10.152.183.254:8180/some_string
Hello from ServerGo. You requested: /some_string
```
