### PR TITLE
Support mayastor addon on arm64 architectures

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -133,10 +133,11 @@ microk8s-addons:
 
     - name: "mayastor"
       description: "OpenEBS MayaStor"
-      version: "1.0.1-alpha1"
+      version: "1.0.1-alpha-2"
       check_status: "daemonset.apps/mayastor"
       supported_architectures:
         - amd64
+        - arm64
 
     - name: "community"
       description: "The community addons repository"

--- a/addons/mayastor/chart/values.yaml
+++ b/addons/mayastor/chart/values.yaml
@@ -6,7 +6,7 @@ rbac:
 # Configuration for etcd-operator chart
 etcd-operator:
   operator:
-    image: cdkbot/etcd-operator:0.10.0-microk8s-2
+    image: cdkbot/etcd-operator:0.10.0-microk8s-3
     enabled: true
   rbac:
     enabled: true
@@ -15,7 +15,7 @@ etcd-operator:
       spec:
         size: 3
         limitSizeToMaxReadyNodes: true
-        version: "3.5.2"
+        version: "3.5.4"
         pod:
           restartPolicy: Always
           hostPathVolume: "/var/snap/microk8s/common/mayastor/etcd/$NAME"
@@ -32,7 +32,7 @@ etcd-operator:
 # Mayastor Control Plane configuration
 mayastor-control-plane:
   mayastorCP:
-    tag: 1.0.1-microk8s-1
+    tag: 1.0.1-microk8s-2
 
   kubeletDir: /var/snap/microk8s/common/var/lib/kubelet
   etcdEndpoint: etcd-client
@@ -56,6 +56,9 @@ mayastor-control-plane:
       image: cdkbot/mayastor-csi-controller
     node:
       image: cdkbot/mayastor-csi-node
+      nodeSelector: []
+      driverRegistrar:
+        image: cdkbot/csi-node-driver-registrar:v2.1.0-microk8s-2
   msp:
     numRetries: 200
     disableDeviceValidation: true
@@ -63,15 +66,14 @@ mayastor-control-plane:
 
 # Mayastor configuration
 mayastor:
-  mayastorImagesTag: 1.0.1-microk8s-1
+  mayastorImagesTag: 1.0.1-microk8s-2
   mayastorImage: cdkbot/mayastor
 
   etcdEndpoint: etcd-client
   etcd:
     enabled: false
 
-  nodeSelector:
-    - kubernetes.io/arch: amd64
+  nodeSelector: []
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/addons/mayastor/enable
+++ b/addons/mayastor/enable
@@ -126,7 +126,8 @@ def main(
     # Print a warning to the user.
     microk8s_img = MAYASTOR_DATA / "microk8s.img"
     if microk8s_img.exists():
-        click.echo(f"""
+        click.echo(
+            f"""
 ============================================================
 
 WARNING: {microk8s_img} already exists.
@@ -136,7 +137,8 @@ can do a clean install of the mayastor addon with:
     microk8s disable mayastor --remove-storage
     microk8s enable mayastor
 
-""")
+"""
+        )
 
     # Install
     subprocess.check_call([HELM, "install", "mayastor", "-n", "mayastor", DIR / "chart", *args])
@@ -154,7 +156,6 @@ Mayastor will run for all nodes in your MicroK8s cluster by default. Use the
 
 """
     )
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Add arm64 support for the mayastor addon.

### Notes

- We keep using images under cdkbot until upstream has multi-arch release image tags.
- We keep using the helm charts from our fork, until our changes get merged upstream.
- The mayastor-msp-operator image contains this change, not yet merged upstream https://github.com/openebs/mayastor-control-plane/pull/251

### Testing

If you don't have an arm64 machine handy, get one from AWS:

```
juju add-machine --constraints 'arch=amd64 mem=4G root-disk=40G cores=4'
juju ssh 0
```

Dependencies:

```
sudo apt-get install linux-modules-extra-$(uname -r)
sudo modprobe nvme-tcp
sudo sysctl vm.nr_hugepages=1024
```

Installation:

```
sudo snap install microk8s --classic --channel 1.24
sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons --reference feature/mayastor-arm64 --force
sudo microk8s enable mayastor
```

### References

- https://github.com/canonical/mayastor-control-plane/commit/3f8d59f2d74981dc7024d3029ea8873f03156005
- https://github.com/canonical/mayastor-control-plane/commit/103b2a6d486f4706eb72b71cf923bb5a34c378cb
- https://github.com/canonical/etcd-operator/commit/39401b6b6d5f9c7a02609bae7b5998d1e837dd3e

Useful reference throughout the whole testing and implementation https://linaro.atlassian.net/browse/STOR-35