### PR TITLE
[gpu] Check prerequisites of driver.enabled=false

### DIFF
--- a/addons/gpu/enable
+++ b/addons/gpu/enable
@@ -23,6 +23,7 @@ else
   if lsmod | grep "nvidia" &> /dev/null
     then
     echo "Using host driver"
+    nvidia-smi -L
     readonly ENABLE_INTERNAL_DRIVER="false"
   else
     echo "Using operator driver"


### PR DESCRIPTION
In addition to the kernel modules, nvidia-smi command must work as a
prerequisite to use driver.enabled=false. If the command fails for
whatever reasons, let's pass through the error to users as follows:

[working]
```
"GPU 0: Tesla V100-SXM2-16GB (UUID: GPU-5e8fe16a-4413-abb0-6bb6-aaaaaaaaaaaa)"
-> ret: 0
```

[fails to communicate with the driver]
```
"NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA
driver. Make sure that the latest NVIDIA driver is installed and
running."
-> ret: 9
```

[command not found]
```
root user:
    nvidia-smi: command not found
-> ret: 1
microk8s group user:
    Command 'nvidia-smi' not found, but can be installed with:
    (...)
    sudo apt install nvidia-utils-510
    sudo apt install nvidia-utils-510-server
-> ret: 127
```

Closes: canonical/microk8s#3219

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
