### PR TITLE
Rework GPU addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -73,7 +73,7 @@ microk8s-addons:
 
     - name: "gpu"
       description: "Automatic enablement of Nvidia CUDA"
-      version: "1.7.0"
+      version: "1.10.1"
       check_status: "daemonset.apps/nvidia-device-plugin-daemonset"
       supported_architectures:
         - amd64

--- a/addons/gpu/disable
+++ b/addons/gpu/disable
@@ -1,11 +1,34 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-set -e
+import os
+import json
+import pathlib
+import subprocess
 
-source $SNAP/actions/common/utils.sh
+import click
 
-echo "Disabling NVIDIA GPU support"
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+HELM = SNAP / "microk8s-helm3.wrapper"
 
-"$SNAP/microk8s-helm3.wrapper" uninstall gpu-operator
 
-echo "GPU support disabled"
+@click.command()
+def main():
+    click.echo("Disabling NVIDIA GPU support")
+    try:
+        stdout = subprocess.check_output([HELM, "ls", "-A", "-o", "json"])
+        charts = json.loads(stdout)
+    except (OSError, json.JSONDecodeError):
+        click.echo("ERROR: Failed to retrieve installed charts", err=True)
+        charts = []
+
+    for chart in charts:
+        name = chart.get("name")
+        if chart.get("name") == "gpu-operator":
+            namespace = chart.get("namespace") or "default"
+            subprocess.run([HELM, "uninstall", name, "-n", namespace])
+
+    click.echo("GPU support disabled")
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/gpu/enable
+++ b/addons/gpu/enable
@@ -1,54 +1,118 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-set -e
+import json
+import os
+import pathlib
+import subprocess
+import time
 
-source $SNAP/actions/common/utils.sh
+import click
 
-readonly CONFIG="$SNAP_DATA/args/containerd-template.toml"
-readonly SOCKET="$SNAP_COMMON/run/containerd.sock"
 
-echo "Enabling NVIDIA GPU"
+DIR = pathlib.Path(__file__).absolute().parent
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA") or "/var/snap/microk8s/current")
+SNAP_CURRENT = SNAP_DATA.parent / "current"
+SNAP_COMMON = pathlib.Path(os.getenv("SNAP_COMMON") or "/var/snap/microk8s/common")
 
-read -ra ARGUMENTS <<< "$1"
+HELM = SNAP / "microk8s-helm3.wrapper"
+MICROK8S_ENABLE = SNAP / "microk8s-enable.wrapper"
+CONTAINERD_SOCKET = SNAP_COMMON / "run" / "containerd.sock"
+CONTAINERD_TOML = SNAP_CURRENT / "args" / "containerd-template.toml"
 
-if [[ "$ARGUMENTS" == "force-system-driver" ]]
-  then
-  echo "Using host driver"
-  readonly ENABLE_INTERNAL_DRIVER="false"
-elif [[ "$ARGUMENTS" == "force-operator-driver" ]]
-  then
-  echo "Using operator driver"
-  readonly ENABLE_INTERNAL_DRIVER="true"
-else
-  if lsmod | grep "nvidia" &> /dev/null
-    then
-    echo "Using host driver"
-    readonly ENABLE_INTERNAL_DRIVER="false"
-  else
-    echo "Using operator driver"
-    readonly ENABLE_INTERNAL_DRIVER="true"
-  fi
-fi
 
-sudo mkdir -p ${SNAP_DATA}/var/lock
-sudo touch ${SNAP_DATA}/var/lock/gpu
+def log(msg):
+    click.echo(msg, err=True)
 
-"$SNAP/microk8s-enable.wrapper" dns
-"$SNAP/microk8s-enable.wrapper" helm3
 
-echo "Installing NVIDIA Operator"
+@click.command()
+@click.argument(
+    "driver-type",
+    default="",
+    type=click.Choice(["", "force-operator-driver", "force-system-driver"]),
+)
+@click.option("--requires", multiple=True, default=["core/dns", "core/helm3"])
+@click.option("--version", default="v1.10.1")
+@click.option("--driver", default="auto", type=click.Choice(["auto", "operator", "host"]))
+@click.option("--toolkit-version", default=None)
+@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, default=True)
+@click.option("--set", "helm_set", multiple=True)
+@click.option("-f", "--values", "helm_values", multiple=True, type=click.Path(exists=True))
+def main(
+    requires: list,
+    version: str,
+    driver_type: str,
+    driver: str,
+    toolkit_version: str,
+    toolkit_containerd_restart_mode: str,
+    set_as_default_runtime: bool,
+    helm_set: list,
+    helm_values: list,
+):
+    click.echo("Enabling NVIDIA GPU")
 
-"$SNAP/microk8s-helm3.wrapper" repo add nvidia https://nvidia.github.io/gpu-operator
-"$SNAP/microk8s-helm3.wrapper" repo update
-"$SNAP/microk8s-helm3.wrapper" install gpu-operator nvidia/gpu-operator \
-  --create-namespace \
-  --namespace gpu-operator-resources \
-  --version=v1.10.1 \
-  --set operator.defaultRuntime=containerd \
-  --set driver.enabled=$ENABLE_INTERNAL_DRIVER \
-  --set toolkit.env[0].name=CONTAINERD_CONFIG \
-  --set toolkit.env[0].value=$CONFIG \
-  --set toolkit.env[1].name=CONTAINERD_SOCKET \
-  --set toolkit.env[1].value=$SOCKET
+    for addon in requires:
+        subprocess.run([MICROK8S_ENABLE, addon])
 
-echo "NVIDIA is enabled"
+    # handle the deprecated force-operator-driver and force-system-driver options
+    if driver_type == "force-operator-driver":
+        driver = "operator"
+        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=operator")
+    elif driver_type == "force-system-driver":
+        driver = "host"
+        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=host")
+    elif driver == "auto":
+        try:
+            click.echo("Checking if NVIDIA driver is already installed")
+            subprocess.check_call(["nvidia-smi", "-L"])
+            driver = "host"
+        except OSError:
+            driver = "operator"
+
+    click.echo(f"Using {driver} GPU driver")
+    helm_args = [
+        "install",
+        "gpu-operator",
+        "nvidia/gpu-operator",
+        f"--version={version}",
+        "--create-namespace",
+        "--namespace=gpu-operator-resources",
+        "-f",
+        "-",
+    ]
+
+    helm_config = {
+        "operator": {
+            "defaultRuntime": "containerd",
+        },
+        "driver": {
+            "enabled": ("true" if driver == "operator" else "false"),
+        },
+        "toolkit": {
+            "enabled": "true",
+            "env": [
+                {"name": "CONTAINERD_CONFIG", "value": CONTAINERD_TOML.as_posix()},
+                {"name": "CONTAINERD_SOCKET", "value": CONTAINERD_SOCKET.as_posix()},
+                {
+                    "name": "CONTAINERD_SET_AS_DEFAULT",
+                    "value": "1" if set_as_default_runtime else "0",
+                },
+            ],
+        },
+    }
+    if toolkit_version is not None:
+        helm_config["toolkit"]["version"] = toolkit_version
+
+    for arg in helm_set:
+        helm_args.extend(["--set", arg])
+    for arg in helm_values:
+        helm_args.extend(["--values", arg])
+
+    subprocess.run([HELM, "repo", "add", "nvidia", "https://nvidia.github.io/gpu-operator"])
+    subprocess.run([HELM, *helm_args], input=json.dumps(helm_config).encode())
+
+    click.echo("NVIDIA is enabled")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

Rework GPU addon. Adds lots of new options:

The simple way to enable the addon is still available and works as it should: `microk8s enable gpu`

### Changes

- Fix regression when removing the GPU addon introduced by #44 
- Check that the host drivers are installed using `nvidia-smi` instead of `lsmod | grep nvidia`.
- Fix the containerd configuration file being passed to the nvidia container toolkit daemonset with a fixed revision number
- Support passing custom configuration values to the gpu-operator helm chart
- Support manual restart of containerd (this is mostly meant for usage in 1.21)

Note that this comes with a number of updates to the [documentation page](https://microk8s.io/docs/addon-gpu)

### Testing

Tested following scenarios:

- 1.21 with host drivers (`--no-backwards-compatible --toolkit-containerd-restart-mode=manual --driver=host`) on a GPU instance with `nvidia-headless-510-server` installed
- 1.21 with operator drivers (`--no-backwards-compatible --toolkit-containerd-restart-mode=manual`)
- 1.24 with operator driver