### PR TITLE
Pin busybox images to 1.34.1-glibc

### DIFF
--- a/addons/hostpath-storage/storage.yaml
+++ b/addons/hostpath-storage/storage.yaml
@@ -31,6 +31,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: PV_DIR
               value: $SNAP_COMMON/default-storage
+            - name: BUSYBOX_IMAGE
+              value: busybox:1.34.1-glibc
           #   - name: PV_RECLAIM_POLICY
           #     value: Retain
           volumeMounts:

--- a/addons/mayastor/chart/values.yaml
+++ b/addons/mayastor/chart/values.yaml
@@ -17,6 +17,7 @@ etcd-operator:
         limitSizeToMaxReadyNodes: true
         version: "3.5.4"
         pod:
+          busyboxImage: busybox:1.34.1-glibc
           restartPolicy: Always
           hostPathVolume: "/var/snap/microk8s/common/mayastor/etcd/$NAME"
           affinity:
@@ -36,6 +37,7 @@ mayastor-control-plane:
 
   kubeletDir: /var/snap/microk8s/common/var/lib/kubelet
   etcdEndpoint: etcd-client
+  busyboxImage: busybox:1.34.1-glibc
 
   base:
     cache_poll_period: "30s"
@@ -96,6 +98,7 @@ mayastor:
         path: /var/snap/microk8s/common/mayastor/data
 
   imageSize: 20G
+  busyboxImage: busybox:1.34.1-glibc
 
   mayastorExtraInitContainers:
     - name: initialize-pool


### PR DESCRIPTION
### Summary

Our addons currently use different versions of busybox. Update to always use the same pinned version.

### Verify

```
$ microk8s addons repo add core https://github.com/canonical/microk8s-core-addons --reference MK-591/pin-busybox-images --force
$ microk8s enable storage mayastor
```

wait for pods to come up, ensure only `busybox:1.34.1-glibc` is used:

```
$ microk8s ctr image ls -q | grep busybox
docker.io/library/busybox:1.34.1-glibc
docker.io/library/busybox@sha256:db203ccc233573e1db3737553e7b511000412306a1420c7f512377e1a5702786
```
