### PR TITLE
Added a strict skipif to skip gpu tests

### DIFF
--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -139,6 +139,10 @@ class TestAddons(object):
         """
 
     @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping GPU tests in strict confinement as they are expected to fail",
+    )
+    @pytest.mark.skipif(
         os.environ.get("UNDER_TIME_PRESSURE") == "True",
         reason="Skipping GPU tests as we are under time pressure",
     )


### PR DESCRIPTION
## Summary
Added a `skipif` based on `STRICT` env variable for the gpu tests in strict since they are expected to fail

### Testing
Add `STRICT="yes"` to the environment variables before calling `pytest`. E.g.

```
sudo STRICT="yes" pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py
```