### PR TITLE
Set the confinement flag of the gpu addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -75,6 +75,7 @@ microk8s-addons:
       description: "Automatic enablement of Nvidia CUDA"
       version: "1.11.0"
       check_status: "daemonset.apps/nvidia-device-plugin-daemonset"
+      confinement: "classic"
       supported_architectures:
         - amd64
 


### PR DESCRIPTION
Set the confinement property of the GPU addon to "classic" so it is not available in the strict builds.
