### PR TITLE
use prettier ignore file to ignore yamls we dont want to check

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -30,10 +30,4 @@ jobs:
       - name: Check YAML formatting
         run: |
           set -eux
-          prettier --check $(find . -name "*.yaml" -o -name "*.yml" \
-            | grep -v "./addons/ingress/ingress.yaml" \
-            | grep -v "./addons/metallb/metallb.yaml" \
-            | grep -v "./addons/cert-manager/cert-manager.yaml" \
-            | grep -v "./addons/kube-ovn/ovn-template.yaml" \
-            | grep -v "./addons/kube-ovn/crd.yaml" \
-            | grep -v "templates")
+          prettier --check **/*.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+**/addons/ingress/ingress.yaml
+**/addons/metallb/metallb.yaml
+**/addons/cert-manager/cert-manager.yaml
+**/addons/kube-ovn/ovn-template.yaml
+**/addons/kube-ovn/crd.yaml
+**/templates/**


### PR DESCRIPTION
This PR uses the `.prettierignore` file to consolidate all the `yaml` files we don't want prettier to check.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
