### PR TITLE
Helm comes pre-installed with MicroK8s

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -80,18 +80,18 @@ microk8s-addons:
         - amd64
 
     - name: "helm"
-      description: "Helm 2 - the package manager for Kubernetes"
-      version: "2.16.0"
-      check_status: "${SNAP_DATA}/bin/helm"
+      description: "Helm - the package manager for Kubernetes"
+      version: "3.9.1"
+      check_status: "${SNAP}/bin/helm"
       supported_architectures:
         - amd64
         - arm64
         - s390x
 
     - name: "helm3"
-      description: "Helm 3 - Kubernetes package manager"
-      version: "3.8.0"
-      check_status: "${SNAP_DATA}/bin/helm3"
+      description: "Helm 3 - the package manager for Kubernetes"
+      version: "3.9.1"
+      check_status: "${SNAP}/bin/helm"
       supported_architectures:
         - amd64
         - arm64

--- a/addons/helm/disable
+++ b/addons/helm/disable
@@ -2,11 +2,4 @@
 
 set -e
 
-source $SNAP/actions/common/utils.sh
-
-echo "Disabling Helm"
-
-if [ -f "${SNAP_DATA}/bin/helm" ]
-then
-  run_with_sudo rm -f "$SNAP_DATA/bin/helm"
-fi
+echo "Helm comes pre-installed with MicroK8s"

--- a/addons/helm/enable
+++ b/addons/helm/enable
@@ -2,28 +2,6 @@
 
 set -e
 
-source $SNAP/actions/common/utils.sh
-
-echo "Enabling Helm"
-
-if [ ! -f "${SNAP_DATA}/bin/helm" ]
-then
-  SOURCE_URI="https://get.helm.sh"
-  HELM_VERSION="v2.16.7"
-
-  echo "Fetching helm version $HELM_VERSION."
-  run_with_sudo mkdir -p "${SNAP_DATA}/tmp/helm"
-  (cd "${SNAP_DATA}/tmp/helm"
-  fetch_as $SOURCE_URI/helm-$HELM_VERSION-linux-$(arch).tar.gz "$SNAP_DATA/tmp/helm/helm.tar.gz"
-  run_with_sudo gzip -f -d "$SNAP_DATA/tmp/helm/helm.tar.gz"
-  run_with_sudo tar -xf "$SNAP_DATA/tmp/helm/helm.tar")
-
-  run_with_sudo mkdir -p "$SNAP_DATA/bin/"
-  run_with_sudo mv "$SNAP_DATA/tmp/helm/linux-$(arch)/helm" "$SNAP_DATA/bin/helm"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/helm"
-
-  run_with_sudo rm -rf "$SNAP_DATA/tmp/helm"
-fi
+echo "Helm comes pre-installed with MicroK8s"
 
 echo "Helm is enabled"

--- a/addons/helm3/disable
+++ b/addons/helm3/disable
@@ -2,11 +2,4 @@
 
 set -e
 
-source $SNAP/actions/common/utils.sh
-
-echo "Disabling Helm 3"
-
-if [ -f "${SNAP_DATA}/bin/helm3" ]
-then
-  run_with_sudo rm -f "$SNAP_DATA/bin/helm3"
-fi
+echo "Helm comes pre-installed with MicroK8s"

--- a/addons/helm3/enable
+++ b/addons/helm3/enable
@@ -2,28 +2,6 @@
 
 set -e
 
-source $SNAP/actions/common/utils.sh
-
-echo "Enabling Helm 3"
-
-if [ ! -f "${SNAP_DATA}/bin/helm3" ]
-then
-  SOURCE_URI="https://get.helm.sh"
-  HELM_VERSION="v3.8.0"
-
-  echo "Fetching helm version $HELM_VERSION."
-  run_with_sudo mkdir -p "${SNAP_DATA}/tmp/helm3"
-  (cd "${SNAP_DATA}/tmp/helm3"
-  fetch_as $SOURCE_URI/helm-$HELM_VERSION-linux-${SNAP_ARCH}.tar.gz "$SNAP_DATA/tmp/helm3/helm.tar.gz"
-  run_with_sudo gzip -f -d "$SNAP_DATA/tmp/helm3/helm.tar.gz"
-  run_with_sudo tar --no-same-owner -xf "$SNAP_DATA/tmp/helm3/helm.tar")
-
-  run_with_sudo mkdir -p "$SNAP_DATA/bin/"
-  run_with_sudo mv "$SNAP_DATA/tmp/helm3/linux-${SNAP_ARCH}/helm" "$SNAP_DATA/bin/helm3"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/helm3"
-
-  run_with_sudo rm -rf "$SNAP_DATA/tmp/helm3"
-fi
+echo "Helm comes pre-installed with MicroK8s"
 
 echo "Helm 3 is enabled"

--- a/addons/observability/disable
+++ b/addons/observability/disable
@@ -5,8 +5,8 @@ source $SNAP/actions/common/utils.sh
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 NAMESPACE_PTR="monitoring"
-KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
-HELM="$SNAP_DATA/bin/helm3 --kubeconfig=$SNAP_DATA/credentials/client.config"
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm.wrapper"
 echo "Disabling observability"
 
 # unload the the manifests

--- a/addons/observability/enable
+++ b/addons/observability/enable
@@ -9,7 +9,7 @@ CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 "$SNAP/microk8s-enable.wrapper" core/hostpath-storage
 
 NAMESPACE_PTR="monitoring"
-KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 
 echo "Enabling observability"
 
@@ -32,7 +32,7 @@ esac
 done
 
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-HELM="$SNAP_DATA/bin/helm3 --kubeconfig=$SNAP_DATA/credentials/client.config"
+HELM="${SNAP}/microk8s-helm3.wrapper"
 $HELM repo add prometheus-community https://prometheus-community.github.io/helm-charts
 $HELM repo add grafana https://grafana.github.io/helm-charts
 $HELM repo update


### PR DESCRIPTION
### Summary

Sibling PR for https://github.com/canonical/microk8s/pull/3324

Starting from MicroK8s 1.25, helm comes pre-installed with the snap.

### Updates

- The `helm` and `helm3` are kept and always appear as enabled. This is to maintain backwards compatibility for downstream usage of `microk8s enable helm3`
- Update the addon version to match the helm binary version