### PR TITLE
Update hostpath-provisioner to version 1.3.0 

### DIFF
--- a/addons/hostpath-storage/storage.yaml
+++ b/addons/hostpath-storage/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner:1.2.0
+          image: cdkbot/hostpath-provisioner:1.3.0
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
### Summary

Update hostpath-provisioner version to 1.3.0

### Changes

- includes reduced resource limits for provisioner pod (https://github.com/canonical/hostpath-provisioner/pull/4)
- includes support for ppc64le (https://github.com/canonical/hostpath-provisioner/pull/6)
