### PR TITLE
[Backport 1.24] Update hostpath-provisioner to 1.3.0

### DIFF
--- a/addons/hostpath-storage/storage.yaml
+++ b/addons/hostpath-storage/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner:1.2.0
+          image: cdkbot/hostpath-provisioner:1.3.0
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
Backport https://github.com/canonical/microk8s-core-addons/pull/73 to 1.24