### PR TITLE
Update addon versions to match installed one

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -21,7 +21,7 @@ microk8s-addons:
 
     - name: "dashboard"
       description: "The Kubernetes dashboard"
-      version: "2.5.1"
+      version: "2.6.0"
       check_status: "pod/kubernetes-dashboard"
       supported_architectures:
         - arm64
@@ -38,7 +38,7 @@ microk8s-addons:
 
     - name: "hostpath-storage"
       description: "Storage class; allocates storage from host directory"
-      version: "1.1.0"
+      version: "1.3.0"
       check_status: "pod/hostpath-provisioner"
       supported_architectures:
         - arm64
@@ -47,7 +47,7 @@ microk8s-addons:
 
     - name: "storage"
       description: "Alias to hostpath-storage add-on, deprecated"
-      version: "1.1.0"
+      version: "1.3.0"
       check_status: "pod/hostpath-provisioner"
       supported_architectures:
         - arm64


### PR DESCRIPTION
### Summary

Update versions of kubernetes-dashboard (has been upgraded to 2.6.0) and hostpath-provisioner (has been upgraded to 1.3.0)