### PR TITLE
Update dashboard to 2.7.0

### DIFF
--- a/addons/dashboard/dashboard.yaml
+++ b/addons/dashboard/dashboard.yaml
@@ -172,7 +172,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubernetes-dashboard
-          image: kubernetesui/dashboard:v2.6.0
+          image: kubernetesui/dashboard:v2.7.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443


### PR DESCRIPTION
### Summary

Upgrade kubernetes dashboard to 2.7.0 to improve support for Kubernetes 1.25