### PR TITLE
(Backport 1.25) Update dashboard to 2.7.0

### DIFF
--- a/addons/dashboard/dashboard.yaml
+++ b/addons/dashboard/dashboard.yaml
@@ -172,7 +172,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubernetes-dashboard
-          image: kubernetesui/dashboard:v2.6.0
+          image: kubernetesui/dashboard:v2.7.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443


### PR DESCRIPTION
### Summary

Update dashboard to 2.7.0 to fix compatibility issues with Kubernetes 1.25