### PR TITLE
Update GPU operator to v22.9.0

### DIFF
--- a/addons/gpu/enable
+++ b/addons/gpu/enable
@@ -32,7 +32,7 @@ def log(msg):
     type=click.Choice(["", "force-operator-driver", "force-system-driver"]),
 )
 @click.option("--requires", multiple=True, default=["core/dns", "core/helm3"])
-@click.option("--version", default="v1.11.0")
+@click.option("--version", default="v22.9.0")
 @click.option("--driver", default="auto", type=click.Choice(["auto", "operator", "host"]))
 @click.option("--toolkit-version", default=None)
 @click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, default=True)


### PR DESCRIPTION
### Summary

Closes https://github.com/canonical/microk8s/issues/3452

Update GPU operator to version [v22.9.0](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/release-notes.html), fixing support for 1.25