### PR TITLE
Rework how upstream nameservers are chosen in the DNS addon

### DIFF
--- a/addons/dns/enable
+++ b/addons/dns/enable
@@ -6,46 +6,53 @@ source $SNAP/actions/common/utils.sh
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 source $CURRENT_DIR/../common/utils.sh
 
-KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+
 # Apply the dns yaml
 # We do not need to see dns pods running at this point just give some slack
 echo "Enabling DNS"
 
 read -ra ARGUMENTS <<< "$1"
-if [[ ! -z "${ARGUMENTS[@]}" ]]
-then
-  nameservers="${ARGUMENTS[@]}"
-else
-  nameservers="8.8.8.8,8.8.4.4"
-fi
-
-# if none passed use resolv.conf
-if [[ $nameservers == "/etc/resolv.conf" ]]
-then
-   nameserver_str="/etc/resolv.conf"
-else
-  REGEX_IP_ADDR='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'
-  # get ip addresses separated by , as a list
-  nameservers_list=(${nameservers//,/ })
-  nameserver_str=""
-  for nameserver in "${nameservers_list[@]}"
-  do
-    if [[ $nameserver =~ $REGEX_IP_ADDR ]]
-    then
-      nameserver_str="${nameserver_str}${nameserver} "
+if [[ -z "${ARGUMENTS[@]}" ]] || [[ "${ARGS[@]}" == "/etc/resolv.conf" ]]; then
+  resolv_conf="$(cat $SNAP_DATA/args/kubelet | grep -- "--resolv-conf" | tr "=" " " | gawk '{print $2}')"
+  if [ ! -z "${resolv_conf}" ]; then
+    # kubelet has a resolv.conf file configured, we will use that one
+    echo "Using host configuration from ${resolv_conf}"
+    nameserver_str="/etc/resolv.conf"
+  else
+    host_resolv_conf="$($SNAP/usr/bin/python3 $SNAP/scripts/find-resolv-conf.py 2> /dev/null || true)"
+    if [ ! -z "${host_resolv_conf}" ]; then
+      # found a host resolv.conf file with non-loopback nameservers, use that one
+      echo "Using host configuration from ${host_resolv_conf}"
+      refresh_opt_in_config "resolv-conf" "${host_resolv_conf}" "kubelet"
+      nameserver_str="/etc/resolv.conf"
     else
-      echo "Your input value ($nameserver) is not a valid IP address"
+      # no resolv.conf file found, fallback to Google DNS servers
+      echo "No valid resolv.conf file could be found"
+      echo "Falling back to 8.8.8.8 8.8.4.4 as upstream nameservers"
+
+      nameserver_str="8.8.8.8 8.8.4.4"
+    fi
+  fi
+else
+  # validate IP addresses
+  nameserver_str=""
+  for ns in ${ARGUMENTS[@]//,/ }; do
+    if ! "${SNAP}/bin/ip" route get "$ns" > /dev/null 2> /dev/null; then
+      echo "Your input value ($ns) is not a valid and reachable IP address"
       exit 1
     fi
+    nameserver_str="${nameserver_str} ${ns}"
   done
+  echo "Will use ${nameserver_str} as upstream nameservers"
 fi
 
 echo "Applying manifest"
 ALLOWESCALATION="false"
-if grep  -e ubuntu /proc/version | grep 16.04 &> /dev/null
-then
+if grep -e ubuntu /proc/version | grep 16.04 &> /dev/null; then
   ALLOWESCALATION="true"
 fi
+
 declare -A map
 map[\$ALLOWESCALATION]="$ALLOWESCALATION"
 map[\$NAMESERVERS]="$nameserver_str"
@@ -53,6 +60,7 @@ use_addon_manifest dns/coredns apply "$(declare -p map)"
 sleep 5
 
 echo "Restarting kubelet"
+
 #TODO(kjackal): do not hardcode the info below. Get it from the yaml
 refresh_opt_in_config "cluster-domain" "cluster.local" kubelet
 refresh_opt_in_config "cluster-dns" "10.152.183.10" kubelet

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -349,15 +349,15 @@ def validate_metallb_config(ip_ranges="192.168.0.105"):
         assert ip_range in out
 
 
-def validate_coredns_config(ip_ranges="8.8.8.8,1.1.1.1"):
+def validate_coredns_config(nameservers="8.8.8.8,1.1.1.1"):
     """
     Validate dns
     """
     out = kubectl("get configmap coredns -n kube-system -o jsonpath='{.data.Corefile}'")
-    expected_forward_val = "forward ."
-    for ip_range in ip_ranges.split(","):
-        expected_forward_val = expected_forward_val + " " + ip_range
-    assert expected_forward_val in out
+    for line in out.split("\n"):
+        if "forward ." in line:
+            for nameserver in nameservers.split(","):
+                assert nameserver in line
 
 
 def validate_mayastor():


### PR DESCRIPTION
### Summary

Rework how upstream nameservers are chosen in the DNS addon. Review along with the sibling PR https://github.com/canonical/microk8s/pull/3487.

### Description

Currently, MicroK8s hardcodes upstream nameservers to 8.8.8.8 and 8.8.4.4. This is not always desirable, because:
- The nameservers may not be reachable in airgap deployments, enterprise environments, etc.
- Breaks name resolution for local hostnames.

We change the behaviour to the following, with the aim of maintaining backwards compatibility whenever possible, but also ensuring that the host resolv.conf file is used when available.

| enable command                           | old behaviour                                  | new behaviour                                                                                                                                                                     |
| ---------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| microk8s enable dns                      | use 8.8.8.8, 8.8.4.4                           | if kubelet has a resolv.conf configured, use it. otherwise, try to find a resolv.conf on the host with non-loopback addresses and use it. otherwise, fallback to 8.8.8.8, 8.8.4.4 |
| microk8s enable dns /etc/resolv.conf     | use whatever was already configured in kubelet | if kubelet has a resolv.conf configured, use it. otherwise, try to find a resolv.conf on the host with non-loopback addresses and use it. otherwise, fallback to 8.8.8.8, 8.8.4.4 |
| microk8s enable dns 1.1.1.1              | validate and use 1.1.1.1                       | validate and use 1.1.1.1                                                                                                                                                          |
| microk8s enable dns 2001:4860:4860::8888 | _fail_                                         | validate and use 2001:4860:4860::8888                                                                                                                                             |

### Additional info

- This PR changes the IP validation check from a dummy regex check (that could allow invalid IPv4 addresses, and always failed with IPv6) to `ip route get`.

- The coredns runs with `dnsPolicy: Default`, which mounts the file configured in kubelet with `--resolv-conf` as `/etc/resolv.conf` inside the pod. By default, this file is the `/etc/resolv.conf` of the host.
