### PR TITLE
Fix the enable and disable ha-cluster addons on strict

### DIFF
--- a/addons/ha-cluster/disable
+++ b/addons/ha-cluster/disable
@@ -46,7 +46,13 @@ workers=$("$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" ge
 run_with_sudo mkdir -p ${SNAP_DATA}/var/log/
 
 echo "Enabling flanneld and etcd"
-run_with_sudo preserve_env LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 002-switch-to-flannel-etcd 2>&1 | run_with_sudo tee ${SNAP_DATA}/var/log/ha-cluster-disable.log &>/dev/null
+if is_strict
+then
+  run_with_sudo ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 002-switch-to-flannel-etcd 2>&1 | run_with_sudo tee ${SNAP_DATA}/var/log/ha-cluster-disable.log &>/dev/null
+else
+  run_with_sudo preserve_env LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 002-switch-to-flannel-etcd 2>&1 | run_with_sudo tee ${SNAP_DATA}/var/log/ha-cluster-disable.log &>/dev/null
+fi
+
 if [ $? -ne 0 ]; then
   echo "Transition to flannel and etcd failed. Please see logs at ${SNAP_DATA}/var/log/ha-cluster-disable.log for more details."
   exit 1

--- a/addons/ha-cluster/enable
+++ b/addons/ha-cluster/enable
@@ -15,7 +15,12 @@ workers=$("$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" ge
 run_with_sudo mkdir -p ${SNAP_DATA}/var/log/
 echo "Enabling HA"
 echo "Upgrading the network CNI"
-run_with_sudo preserve_env LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 000-switch-to-calico 2>&1 | run_with_sudo tee ${SNAP_DATA}/var/log/ha-cluster-upgrade.log &>/dev/null
+if is_strict
+then
+  run_with_sudo ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 000-switch-to-calico 2>&1 | run_with_sudo tee ${SNAP_DATA}/var/log/ha-cluster-upgrade.log &>/dev/null
+else
+  run_with_sudo preserve_env LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 000-switch-to-calico 2>&1 | run_with_sudo tee ${SNAP_DATA}/var/log/ha-cluster-upgrade.log &>/dev/null
+fi
 if [ $? -ne 0 ]; then
   echo "CNI upgrade failed. Please see logs at ${SNAP_DATA}/var/log/ha-cluster-upgrade.log for more details."
   echo "HA configuration aborted"
@@ -30,7 +35,12 @@ echo "Waiting for the CNI to deploy"
 "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n kube-system rollout status deployment/calico-kube-controllers
 
 echo "Configuring the datastore"
-run_with_sudo preserve_env LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 001-switch-to-dqlite 2>&1 | run_with_sudo tee -a ${SNAP_DATA}/var/log/ha-cluster-upgrade.log &>/dev/null
+if is_strict
+then
+  run_with_sudo ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 001-switch-to-dqlite 2>&1 | run_with_sudo tee -a ${SNAP_DATA}/var/log/ha-cluster-upgrade.log &>/dev/null
+else
+  run_with_sudo preserve_env LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/upgrade.py -r 001-switch-to-dqlite 2>&1 | run_with_sudo tee -a ${SNAP_DATA}/var/log/ha-cluster-upgrade.log &>/dev/null
+fi
 if [ $? -ne 0 ]; then
   echo "Datastore upgrade failed. Please see logs at ${SNAP_DATA}/var/log/ha-cluster-upgrade.log for more details."
   echo "HA configuration aborted"


### PR DESCRIPTION
We need to call the python scripts without preserving the env variables in strict.