### PR TITLE
[metallb] create ipaddresspool before waiting for deployment

### DIFF
--- a/addons/metallb/enable
+++ b/addons/metallb/enable
@@ -57,9 +57,9 @@ echo "Applying Metallb manifest"
 $KUBECTL apply -f $CURRENT_DIR/crd.yaml
 
 cat $CURRENT_DIR/metallb.yaml | $SNAP/bin/sed "s@{{allow_escalation}}@$ALLOWESCALATION@g" | $KUBECTL apply -f -
+cat $CURRENT_DIR/addresspool.yaml | $SNAP/bin/sed "s@{{addresses}}@$ip_range_str@g" | $KUBECTL apply -f -
 
 echo "Waiting for Metallb controller to be ready."
 $KUBECTL -n metallb-system  wait deployment controller --for condition=Available=True --timeout=90s
-cat $CURRENT_DIR/addresspool.yaml | $SNAP/bin/sed "s@{{addresses}}@$ip_range_str@g" | $KUBECTL apply -f -
 
 echo "MetalLB is enabled"


### PR DESCRIPTION
Create IPAddressPool before waiting for metallb deployment to be available.

Fixes: #118

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
