### PR TITLE
Observability addon improvements

### DIFF
--- a/addons/observability/disable
+++ b/addons/observability/disable
@@ -4,15 +4,16 @@ set -e
 source $SNAP/actions/common/utils.sh
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
-NAMESPACE_PTR="observability"
+NAMESPACE="observability"
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 HELM="$SNAP/microk8s-helm.wrapper"
 echo "Disabling observability"
 
 # unload the the manifests
-$HELM delete kube-prom-stack -n $NAMESPACE_PTR > /dev/null 2>&1
-# This line below is to address an upstream bug
+$HELM uninstall kube-prom-stack -n $NAMESPACE > /dev/null 2>&1
+# The kubelet service is managed by Prometheus Operator, not by the chart.
+# See: https://github.com/prometheus-community/helm-charts/blob/ddd351fb61030becfe855f6cce664d53b0177e4b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml#L51
 $KUBECTL delete service kube-prom-stack-kube-prome-kubelet -n kube-system
-$HELM delete loki -n $NAMESPACE_PTR > /dev/null 2>&1
-$HELM delete tempo -n $NAMESPACE_PTR > /dev/null 2>&1
-$KUBECTL delete namespace $NAMESPACE_PTR
+$HELM uninstall loki -n $NAMESPACE > /dev/null 2>&1
+$HELM uninstall tempo -n $NAMESPACE > /dev/null 2>&1
+$KUBECTL delete namespace $NAMESPACE

--- a/addons/observability/enable
+++ b/addons/observability/enable
@@ -8,51 +8,78 @@ CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 "$SNAP/microk8s-enable.wrapper" core/helm3
 "$SNAP/microk8s-enable.wrapper" core/hostpath-storage
 
-NAMESPACE_PTR="observability"
+NAMESPACE="observability"
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 
 echo "Enabling observability"
 
-# make sure the "monitoring" namespace exists
-$KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
-# load the CRD and wait for it to be installed
-VALUES="$@"
-
-for i in "$@"
-do
-case $i in
-    -f=*|--values=*)
-    VALUES="${i#*=}"
-    shift # past argument=value
-    ;;
+KUBE_PROM_STACK_VALUES=
+KUBE_PROM_STACK_VERSION=
+LOKI_STACK_VALUES=
+LOKI_STACK_VERSION=
+TEMPO_VALUES=
+TEMPO_VERSION=
+WITHOUT_TEMPO=
+while [ $# -ge 1 ]; do
+  case $1 in
+    --kube-prometheus-stack-values=*)
+      KUBE_PROM_STACK_VALUES="${1#*=}"
+      shift
+      ;;
+    --kube-prometheus-stack-version=*)
+      KUBE_PROM_STACK_VERSION="${1#*=}"
+      shift
+      ;;
+    --loki-stack-values=*)
+      LOKI_STACK_VALUES="${1#*=}"
+      shift
+      ;;
+    --loki-stack-version=*)
+      LOKI_STACK_VERSION="${1#*=}"
+      shift
+      ;;
+    --tempo-values=*)
+      TEMPO_VALUES="${1#*=}"
+      shift
+      ;;
+    --tempo-version=*)
+      TEMPO_VERSION="${1#*=}"
+      shift
+      ;;
+    --without-tempo)
+      WITHOUT_TEMPO=1
+      shift
+      ;;
     *)
-          # unknown option
-    ;;
-esac
+      echo "Unknown option ${1}" >&2
+      exit 1
+      ;;
+  esac
 done
 
 # get addresses of all nodes to configure kubeControllerManager and kubeScheduler endpoints
 NODE_ENDPOINTS=$($KUBECTL get nodes -o jsonpath={.items[*].status.addresses[?\(@.type==\"InternalIP\"\)].address} | sed 's/\s\+/,/g')
-
-SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 HELM="${SNAP}/microk8s-helm3.wrapper"
-$HELM repo add prometheus-community https://prometheus-community.github.io/helm-charts
-$HELM repo add grafana https://grafana.github.io/helm-charts
-$HELM repo update
-if [ -z "$VALUES" ]
-then
-  $HELM upgrade --install kube-prom-stack -f ${SCRIPT_DIR}/grafana.yaml \
-    --set kubeControllerManager.endpoints={$NODE_ENDPOINTS} \
-    --set kubeProxy.endpoints={$NODE_ENDPOINTS} \
-    --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
-    prometheus-community/kube-prometheus-stack -n $NAMESPACE_PTR
-else
-  $HELM upgrade --install kube-prom-stack -f ${SCRIPT_DIR}/grafana.yaml -f "$2" \
-    --set kubeControllerManager.endpoints={$NODE_ENDPOINTS} \
-    --set kubeProxy.endpoints={$NODE_ENDPOINTS} \
-    --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
-    prometheus-community/kube-prometheus-stack -n $NAMESPACE_PTR
+
+HELM_OPTS=
+if [ -n "${KUBE_PROM_STACK_VALUES}" ]; then
+  HELM_OPTS+="--values ${KUBE_PROM_STACK_VALUES} "
 fi
+if [ -n "${KUBE_PROM_STACK_VERSION}" ]; then
+  HELM_OPTS+="--version ${KUBE_PROM_STACK_VERSION} "
+fi
+HELM_OPTS+="--set grafana.additionalDataSources[0].name=loki,grafana.additionalDataSources[0].type=loki,grafana.additionalDataSources[0].url=http://loki.observability.svc.cluster.local:3100 "
+if [ -z "${WITHOUT_TEMPO}" ]; then
+  HELM_OPTS+="--set grafana.additionalDataSources[1].name=tempo,grafana.additionalDataSources[1].type=tempo,grafana.additionalDataSources[1].url=http://tempo.observability.svc.cluster.local:3100 "
+fi
+
+$HELM upgrade --install kube-prom-stack kube-prometheus-stack \
+  --repo https://prometheus-community.github.io/helm-charts \
+  --create-namespace --namespace $NAMESPACE \
+  --set kubeControllerManager.endpoints={$NODE_ENDPOINTS} \
+  --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
+  ${HELM_OPTS}
+
 refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
 refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
 restart_service scheduler
@@ -62,8 +89,30 @@ restart_service controller-manager
 refresh_opt_in_config "metrics-bind-address" "0.0.0.0:10249" kube-proxy
 restart_service proxy
 
-$HELM upgrade --install loki grafana/loki-stack -n $NAMESPACE_PTR --set="grafana.sidecar.datasources.enabled=false"
-$HELM upgrade --install tempo grafana/tempo -n $NAMESPACE_PTR
+HELM_OPTS=
+if [ -n "${LOKI_STACK_VALUES}" ]; then
+  HELM_OPTS+="--values ${LOKI_STACK_VALUES} "
+fi
+if [ -n "${LOKI_STACK_VERSION}" ]; then
+  HELM_OPTS+="--version ${LOKI_STACK_VERSION} "
+fi
+$HELM upgrade --install loki loki-stack \
+  --repo https://grafana.github.io/helm-charts \
+  --create-namespace --namespace $NAMESPACE \
+  --set="grafana.sidecar.datasources.enabled=false" \
+  ${HELM_OPTS}
+
+if [ -z "${WITHOUT_TEMPO}" ]; then
+  HELM_OPTS=
+  if [ -n "${TEMPO_VALUES}" ]; then
+    HELM_OPTS+="--values ${TEMPO_VALUES} "
+  fi
+  if [ -n "${TEMPO_VERSION}" ]; then
+    HELM_OPTS+="--version ${TEMPO_VERSION} "
+  fi
+  $HELM upgrade --install tempo tempo --repo https://grafana.github.io/helm-charts --create-namespace --namespace $NAMESPACE ${HELM_OPTS}
+fi
+
 echo ""
 echo "Note: the observability stack is setup to monitor only the current nodes of the MicroK8s cluster."
 echo "For any nodes joining the cluster at a later stage this addon will need to be set up again."

--- a/addons/observability/enable
+++ b/addons/observability/enable
@@ -80,15 +80,6 @@ $HELM upgrade --install kube-prom-stack kube-prometheus-stack \
   --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
   ${HELM_OPTS}
 
-refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
-refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
-restart_service scheduler
-refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/controller.config" kube-controller-manager
-refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/controller.config" kube-controller-manager
-restart_service controller-manager
-refresh_opt_in_config "metrics-bind-address" "0.0.0.0:10249" kube-proxy
-restart_service proxy
-
 HELM_OPTS=
 if [ -n "${LOKI_STACK_VALUES}" ]; then
   HELM_OPTS+="--values ${LOKI_STACK_VALUES} "
@@ -112,6 +103,15 @@ if [ -z "${WITHOUT_TEMPO}" ]; then
   fi
   $HELM upgrade --install tempo tempo --repo https://grafana.github.io/helm-charts --create-namespace --namespace $NAMESPACE ${HELM_OPTS}
 fi
+
+refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
+refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
+restart_service scheduler
+refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/controller.config" kube-controller-manager
+refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/controller.config" kube-controller-manager
+restart_service controller-manager
+refresh_opt_in_config "metrics-bind-address" "0.0.0.0:10249" kube-proxy
+restart_service proxy
 
 echo ""
 echo "Note: the observability stack is setup to monitor only the current nodes of the MicroK8s cluster."

--- a/addons/observability/grafana.yaml
+++ b/addons/observability/grafana.yaml
@@ -1,8 +1,0 @@
-grafana:
-  additionalDataSources:
-    - name: loki
-      type: loki
-      url: http://loki.observability.svc.cluster.local:3100
-    - name: tempo
-      type: tempo
-      url: http://tempo.observability.svc.cluster.local:3100


### PR DESCRIPTION
- allow the user to specify custom Helm values for all the charts
  installed by this addon
- allow the user to set the chart version to deploy, by default the
  latest one is picked
- make Tempo optional