### PR TITLE
Observability: fix Kubernetes components monitoring

### DIFF
--- a/addons/observability/enable
+++ b/addons/observability/enable
@@ -65,3 +65,5 @@ restart_service proxy
 $HELM upgrade --install loki grafana/loki-stack -n $NAMESPACE_PTR --set="grafana.sidecar.datasources.enabled=false"
 $HELM upgrade --install tempo grafana/tempo -n $NAMESPACE_PTR
 echo "Observability has been enabled (user/pass: admin/prom-operator)"
+echo "In case of a MicroK8s cluster please keep in mind that this addon has only be set up on the current nodes"
+echo "For any node joining the cluster at a later stage this addon will need to be set up again"

--- a/addons/observability/enable
+++ b/addons/observability/enable
@@ -53,17 +53,19 @@ else
     --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
     prometheus-community/kube-prometheus-stack -n $NAMESPACE_PTR
 fi
-refresh_opt_in_config "authentication-kubeconfig" "${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
-refresh_opt_in_config "authorization-kubeconfig" "${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
+refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
+refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
 restart_service scheduler
-refresh_opt_in_config "authentication-kubeconfig" "${SNAP_DATA}/credentials/controller.config" kube-controller-manager
-refresh_opt_in_config "authorization-kubeconfig" "${SNAP_DATA}/credentials/controller.config" kube-controller-manager
+refresh_opt_in_config "authentication-kubeconfig" "\${SNAP_DATA}/credentials/controller.config" kube-controller-manager
+refresh_opt_in_config "authorization-kubeconfig" "\${SNAP_DATA}/credentials/controller.config" kube-controller-manager
 restart_service controller-manager
 refresh_opt_in_config "metrics-bind-address" "0.0.0.0:10249" kube-proxy
 restart_service proxy
 
 $HELM upgrade --install loki grafana/loki-stack -n $NAMESPACE_PTR --set="grafana.sidecar.datasources.enabled=false"
 $HELM upgrade --install tempo grafana/tempo -n $NAMESPACE_PTR
+echo ""
+echo "Note: the observability stack is setup to monitor only the current nodes of the MicroK8s cluster."
+echo "For any nodes joining the cluster at a later stage this addon will need to be set up again."
+echo ""
 echo "Observability has been enabled (user/pass: admin/prom-operator)"
-echo "In case of a MicroK8s cluster please keep in mind that this addon has only be set up on the current nodes"
-echo "For any node joining the cluster at a later stage this addon will need to be set up again"

--- a/addons/observability/enable
+++ b/addons/observability/enable
@@ -43,14 +43,24 @@ if [ -z "$VALUES" ]
 then
   $HELM upgrade --install kube-prom-stack -f ${SCRIPT_DIR}/grafana.yaml \
     --set kubeControllerManager.endpoints={$NODE_ENDPOINTS} \
+    --set kubeProxy.endpoints={$NODE_ENDPOINTS} \
     --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
     prometheus-community/kube-prometheus-stack -n $NAMESPACE_PTR
 else
   $HELM upgrade --install kube-prom-stack -f ${SCRIPT_DIR}/grafana.yaml -f "$2" \
     --set kubeControllerManager.endpoints={$NODE_ENDPOINTS} \
+    --set kubeProxy.endpoints={$NODE_ENDPOINTS} \
     --set kubeScheduler.endpoints={$NODE_ENDPOINTS} \
     prometheus-community/kube-prometheus-stack -n $NAMESPACE_PTR
 fi
+refresh_opt_in_config "authentication-kubeconfig" "${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
+refresh_opt_in_config "authorization-kubeconfig" "${SNAP_DATA}/credentials/scheduler.config" kube-scheduler
+restart_service scheduler
+refresh_opt_in_config "authentication-kubeconfig" "${SNAP_DATA}/credentials/controller.config" kube-controller-manager
+refresh_opt_in_config "authorization-kubeconfig" "${SNAP_DATA}/credentials/controller.config" kube-controller-manager
+restart_service controller-manager
+refresh_opt_in_config "metrics-bind-address" "0.0.0.0:10249" kube-proxy
+restart_service proxy
 
 $HELM upgrade --install loki grafana/loki-stack -n $NAMESPACE_PTR --set="grafana.sidecar.datasources.enabled=false"
 $HELM upgrade --install tempo grafana/tempo -n $NAMESPACE_PTR


### PR DESCRIPTION
- Configure the scheduler and the controller-manager to authentify and to
authorize the incoming requests.
- Configure the kube-proxy endpoints and make it listen to the metrics
  requests on all interfaces

Fixes canonical/microk8s#2379.

Before:
![Capture d’écran du 2022-11-09 15-39-52](https://user-images.githubusercontent.com/17550475/200869086-5d31b4ae-5fbd-444c-b972-c289e6ce8f3e.png)

After:
![Capture d’écran du 2022-11-09 16-06-03](https://user-images.githubusercontent.com/17550475/200869112-6a4dcb26-cc25-4f22-be2e-f0875f1d4fae.png)
