### PR TITLE
Bump hostpath-provisioner to 1.4.2

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -41,7 +41,7 @@ microk8s-addons:
 
     - name: "hostpath-storage"
       description: "Storage class; allocates storage from host directory"
-      version: "1.4.1"
+      version: "1.4.2"
       check_status: "deployment.apps/hostpath-provisioner"
       supported_architectures:
         - arm64

--- a/addons/hostpath-storage/storage.yaml
+++ b/addons/hostpath-storage/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner:1.4.1
+          image: cdkbot/hostpath-provisioner:1.4.2
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
Includes https://github.com/canonical/hostpath-provisioner/pull/8
