### PR TITLE
Upgrade ingress to 1.5.1 to address cve

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -33,7 +33,7 @@ microk8s-addons:
 
     - name: "ingress"
       description: "Ingress controller for external access"
-      version: "1.2.0"
+      version: "1.5.1"
       check_status: "pod/nginx-ingress-microk8s-controller"
       supported_architectures:
         - arm64

--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -24,7 +24,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="v1.2.0"
+TAG="v1.5.1"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 

--- a/addons/ingress/ingress.yaml
+++ b/addons/ingress/ingress.yaml
@@ -81,6 +81,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -112,6 +120,17 @@ rules:
   - configmaps
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Description

The new version 1.5.1 of the ingress controller includes some security fixes. This PR bumps the version that will be used by the ingress microk8s addon.

### Testing

In order to test it, I have done the following:

- Snapcraft build microk8s locally pointing to my forked repo with the 1.5.1 ingress version.

- Enable the ingress addon
```
$ microk8s enable ingress
```
- Check that indeed the right version was installed with:


```
$ microk8s kubectl get pods -n ingress -oyaml | grep -i image: | grep ingress
      image: registry.k8s.io/ingress-nginx/controller:v1.5.1
```


-  I check that it works by exposing a node port service:

```
$ microk8s kubectl create deployment nginx -n ingress --image=nginx --port 80

$ microk8s kubectl expose -n ingress deployment nginx --type=NodePort 

$ microk8s kubectl get svc  -n ingress 
NAME    TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
nginx   NodePort   10.152.183.197   <none>        80:30490/TCP   24s

# Checking that the app is available at K8S_node_IP:30490
$ curl K8S_node_IP:32490
...
<title>Welcome to nginx!</title>
...
```
