### PR TITLE
Add warning for hostpath storage size limitation

### DIFF
--- a/addons/hostpath-storage/enable
+++ b/addons/hostpath-storage/enable
@@ -49,6 +49,8 @@ fi
 echo "Enabling default storage class."
 echo "WARNING: Hostpath storage is not suitable for production environments."
 echo ""
+echo "WARNING: Hostpath storage addon does not respect the volume size defined in the volume manifest. It can go beyond the set size limits."
+echo ""
 run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
 
 declare -A map

--- a/addons/hostpath-storage/enable
+++ b/addons/hostpath-storage/enable
@@ -48,8 +48,7 @@ fi
 
 echo "Enabling default storage class."
 echo "WARNING: Hostpath storage is not suitable for production environments."
-echo ""
-echo "WARNING: Hostpath storage addon does not respect the volume size defined in the volume manifest. It can go beyond the set size limits."
+echo "         A hostpath volume can grow beyond the size limit set in the volume claim manifest."
 echo ""
 run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
 


### PR DESCRIPTION
Added warning to state the limitation of hostpath storage addon to not follow the size set by users, which can sometimes go beyond the set size limit too.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
