### PR TITLE
Skip needless service restarts when enabling addons

### DIFF
--- a/addons/dns/enable
+++ b/addons/dns/enable
@@ -59,12 +59,20 @@ map[\$NAMESERVERS]="$nameserver_str"
 use_addon_manifest dns/coredns apply "$(declare -p map)"
 sleep 5
 
-echo "Restarting kubelet"
+needs_restart=false
+if ! grep -q -- --cluster-domain=cluster.local "${SNAP_DATA}/args/kubelet"; then
+  needs_restart=true
+elif ! grep -q -- --cluster-dns=10.152.183.10 "${SNAP_DATA}/args/kubelet"; then
+  needs_restart=true
+fi
 
 #TODO(kjackal): do not hardcode the info below. Get it from the yaml
 refresh_opt_in_config "cluster-domain" "cluster.local" kubelet
 refresh_opt_in_config "cluster-dns" "10.152.183.10" kubelet
 
-restart_service kubelet
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ] || [ "$needs_restart" = "true" ]; then
+  echo "Restarting kubelet"
+  restart_service kubelet
+fi
 
 echo "DNS is enabled"

--- a/addons/metrics-server/enable
+++ b/addons/metrics-server/enable
@@ -11,7 +11,16 @@ echo "Enabling Metrics-Server"
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 use_addon_manifest metrics-server/metrics-server apply
 
+needs_restart=false
+if ! grep -q -- --authentication-token-webhook=true "${SNAP_DATA}/args/kubelet"; then
+  needs_restart=true
+fi
+
 refresh_opt_in_config "authentication-token-webhook" "true" kubelet
-restart_service kubelet
+
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ] || [ "$needs_restart" = "true" ]; then
+  echo "Restarting kubelet"
+  restart_service kubelet
+fi
 
 echo "Metrics-Server is enabled"

--- a/addons/rbac/enable
+++ b/addons/rbac/enable
@@ -7,7 +7,17 @@ source $SNAP/actions/common/utils.sh
 echo "Enabling RBAC"
 
 echo "Reconfiguring apiserver"
+
+needs_restart=false
+if ! grep -q -- --authorization-mode=RBAC,Node "${SNAP_DATA}/args/kube-apiserver"; then
+  needs_restart=true
+fi
+
 refresh_opt_in_config "authorization-mode" "RBAC,Node" kube-apiserver
-restart_service apiserver
+
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ] || [ "$needs_restart" = "true" ]; then
+  echo "Restarting apiserver"
+  restart_service apiserver
+fi
 
 echo "RBAC is enabled"


### PR DESCRIPTION
### Summary

Do not restart services if they already had the correct configuration flags.

Also adding a note for future reference, in case we see issues arising from this.