### PR TITLE
Bump CoreDNS to 1.10.0

### DIFF
--- a/addons/dns/coredns.yaml
+++ b/addons/dns/coredns.yaml
@@ -83,7 +83,7 @@ spec:
                 path: Corefile
       containers:
         - name: coredns
-          image: coredns/coredns:1.9.3
+          image: coredns/coredns:1.10.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -56,6 +56,7 @@ class TestAddons(object):
         expected["ha-cluster"] = "enabled"
         expected["helm"] = "enabled"
         expected["helm3"] = "enabled"
+        expected["dns"] = "enabled"
 
         assert expected == {a["name"]: a["status"] for a in status["addons"]}
 
@@ -80,6 +81,7 @@ class TestAddons(object):
         """
         ip_ranges = "8.8.8.8,1.1.1.1"
         print("Enabling DNS")
+        microk8s_disable("dns")
         microk8s_enable("{}:{}".format("dns", ip_ranges), timeout_insec=500)
         wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
         print("Validating DNS config")
@@ -107,6 +109,7 @@ class TestAddons(object):
         """
         ip_ranges = "8.8.8.8,1.1.1.1"
         print("Enabling DNS")
+        microk8s_disable("dns")
         microk8s_enable("{}:{}".format("dns", ip_ranges), timeout_insec=500)
         wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
         print("Validating DNS config")


### PR DESCRIPTION
### Summary

Update CoreDNS to 1.10.0.

### Notes

Update coredns tests as well now that we enable DNS by default on new clusters