### PR TITLE
Drop sh from tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh
+          sudo pip3 install -U pytest
       - name: Running addons tests
         run: |
           set -x

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import platform
-import sh
+import subprocess
 import yaml
 from pathlib import Path
 
@@ -45,13 +45,13 @@ class TestAddons(object):
         microk8s_reset()
 
     def test_invalid_addon(self):
-        with pytest.raises(sh.ErrorReturnCode_1):
-            sh.microk8s.enable.foo()
+        p = subprocess.run(["microk8s", "enable", "foo"])
+        assert p.returncode == 1
 
     def test_help_text(self):
-        status = yaml.safe_load(
-            sh.microk8s.status("--wait-ready", "--timeout=600", format="yaml").stdout
-        )
+        cmd = ["microk8s", "status", "--wait-ready", "--timeout=600", "--format=yaml"]
+        status = yaml.safe_load(subprocess.check_output(cmd))
+
         expected = {a["name"]: "disabled" for a in status["addons"]}
         expected["ha-cluster"] = "enabled"
         expected["helm"] = "enabled"
@@ -61,12 +61,14 @@ class TestAddons(object):
         assert expected == {a["name"]: a["status"] for a in status["addons"]}
 
         for addon in status["addons"]:
-            sh.microk8s.enable(addon["name"], "--", "--help")
+            subprocess.check_call(["microk8s", "enable", addon["name"], "--", "--help"])
 
         assert expected == {a["name"]: a["status"] for a in status["addons"]}
 
         for addon in status["addons"]:
-            sh.microk8s.disable(addon["name"], "--", "--help")
+            subprocess.check_call(
+                ["microk8s", "disable", addon["name"], "--", "--help"]
+            )
 
         assert expected == {a["name"]: a["status"] for a in status["addons"]}
 


### PR DESCRIPTION
### Summary

use subprocess instead of `sh` for testing addons.

we do not require any extra sh features, stick to the standard library. also, `sh` came out with version 2.0.0 which breaks our CI