### PR TITLE
Upgrade Mayastor to version 2.0.0

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -139,7 +139,7 @@ microk8s-addons:
 
     - name: "mayastor"
       description: "OpenEBS MayaStor"
-      version: "1.0.1-alpha-2"
+      version: "2.0.0-microk8s-1"
       check_status: "daemonset.apps/mayastor"
       supported_architectures:
         - amd64

--- a/addons/mayastor/chart/Chart.yaml
+++ b/addons/mayastor/chart/Chart.yaml
@@ -3,9 +3,9 @@ name: mayastor-aio
 description: A Helm chart to deploy zero-ops Mayastor to a Kubernetes cluster
 
 type: application
-version: 0.0.1
+version: 2.0.0-microk8s-1
 
-appVersion: "1.0.1"
+appVersion: "2.0.0-microk8s-1"
 
 dependencies:
   - name: etcd-operator
@@ -13,9 +13,5 @@ dependencies:
     repository: https://raw.githubusercontent.com/canonical/etcd-operator/master/chart
   # TODO(neoaggelos): Replace this with repository after upstream release of our changes
   - name: mayastor
-    version: 0.0.1
-    repository: https://raw.githubusercontent.com/canonical/mayastor/develop/chart
-  # TODO(neoaggelos): Replace this with repository after upstream release of our changes
-  - name: mayastor-control-plane
-    version: 0.0.1
-    repository: https://raw.githubusercontent.com/canonical/mayastor-control-plane/develop/chart
+    version: 2.0.0-microk8s-1
+    repository: https://github.com/canonical/mayastor-extensions/releases/download/v2.0.0-microk8s-1

--- a/addons/mayastor/chart/README.md
+++ b/addons/mayastor/chart/README.md
@@ -11,8 +11,7 @@ microk8s enable mayastor
 This Helm Chart has the following dependency Helm Charts:
 
 - [`etcd-operator`](https://github.com/canonical/etcd-operator): An operator that deploys and manages an etcd cluster. Mayastor needs an etcd cluster as backing storage.
-- [`mayastor`](https://github.com/canonical/mayastor): The Mayastor data plane service.
-- [`mayastor-control-plane`](https://github.com/canonical/mayastor-control-plane): The mayastor control plane and accompanying Kubernetes CSI services.
+- [`mayastor`](https://github.com/canonical/mayastor-extensions): The Mayastor control plane and data plane helm chart.
 
 The dependency versions are defined in [`Chart.yaml`](./Chart.yaml) and configured by values set in [`values.yaml`](./values.yaml).
 
@@ -47,130 +46,115 @@ helm repo index
 
 If updating to a new version, make sure to update the version in [Chart.yaml](./Chart.yaml) as well.
 
-### mayastor Helm Chart
+### mayastor
 
-The mayastor Helm Chart deploys the mayastor data plane service.
+#### Docker Images for amd64 and arm64
 
-#### Docker Image
+Repeat the steps below in an amd64 and an arm64 environment.
 
-1.  Install nix
+1.  Install nix and enable environment
 
     ```bash
     curl -L https://nixos.org/nix/install | sh
+    . $HOME/.nix-profile/etc/profile.d/nix.sh
     ```
 
-2.  Clone the repository and setup nix:
+2.  Clone the repository on the desired tag and setup nix:
 
     ```bash
-    git clone https://github.com/canonical/mayastor -b develop
-    cd mayastor
-    git submodule update --init
-    nix-shell
+    export MAYASTOR_TAG=v2.0.0
+    git clone https://github.com/openebs/mayastor -b $MAYASTOR_TAG
+    git clone https://github.com/openebs/mayastor-control-plane -b $MAYASTOR_TAG
+    (cd mayastor && git submodule update --init --recursive)
+    (cd mayastor-control-plane && git submodule update --init --recursive)
     ```
 
-3.  From within the nix-shell, build the Docker image. The resulting image will be created under `/nix/store/...`. A symlink called `result` is placed in the current directory.
+3.  Build the Docker images. The resulting image will be created under `/nix/store/...`. A symlink called `result` is placed in the current directory. This will take a long time.
 
     ```bash
-    nix-build -A images.mayastor
+    (cd mayastor && nix-build -A images.mayastor-io-engine)
+    (cd mayastor-control-plane && nix-build -A images.release)
     ```
 
-4.  Load the image in Docker and note the tag
+    If this fails, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#link-failed)
+
+4.  Load the images in Docker and note the tag
 
     ```bash
-    docker load -i ./result
+    for x in mayastor/result* mayastor-control-plane/result*; do
+        sudo docker load -i $x
+    done
     ```
 
-    Example output (the tag is ``):
-
-    ```
-    Loaded image: mayadata/mayastor:3dc40bb4b460
-    ```
-
-5.  Tag the image under cdkbot/mayastor:TAG and push.
+    Example list of images (note that we do not need all of them for the mayastor addon):
 
     ```bash
-    docker tag mayadata/mayastor:3dc40bb4b460 cdkbot/mayastor:1.0.1-microk8s-1
-    docker push cdkbot/mayastor:1.0.1-microk8s-1
+    $ sudo docker image ls
+    REPOSITORY                           TAG       IMAGE ID       CREATED        SIZE
+    openebs/mayastor-csi-node            v2.0.0    804c529f24f1   26 hours ago   249MB
+    openebs/mayastor-operator-diskpool   v2.0.0    71bad3e6838a   26 hours ago   57.1MB
+    openebs/mayastor-agent-jsongrpc      v2.0.0    061e1df61cfb   26 hours ago   50.5MB
+    openebs/mayastor-api-rest            v2.0.0    b8ef2864ca66   26 hours ago   60MB
+    openebs/mayastor-csi-controller      v2.0.0    73d39122ec17   26 hours ago   58.6MB
+    openebs/mayastor-agent-core          v2.0.0    116805a5bb8a   26 hours ago   67.8MB
+    openebs/mayastor-io-engine           v2.0.0    1087da68d90e   28 hours ago   548MB
     ```
 
-6.  Update the values of `mayastor.mayastorImage` and `mayastor.mayastorImagesTag` in [`values.yaml`](./values.yaml) accordingly.
+5.  Tag and push images for `cdkbot` for the current architecture.
+
+    ```bash
+    export MAYASTOR_TAG=v2.0.0
+    export ARCH_TAG=${MAYASTOR_TAG}-microk8s-1-arm64
+    for image in csi-node operator-diskpool api-rest csi-controller agent-core io-engine; do
+        docker tag openebs/mayastor-$image:$MAYASTOR_TAG cdkbot/mayastor-$image:$ARCH_TAG
+        docker push cdkbot/mayastor-$image:$ARCH_TAG
+    done
+    ```
+
+#### Multi-arch docker images
+
+After building images for amd64 and arm64, create a manifest for each image like so:
+
+```bash
+export MAYASTOR_TAG=v2.0.0
+export TAG=${MAYASTOR_TAG}-microk8s-1
+for image in csi-node operator-diskpool api-rest csi-controller agent-core io-engine; do
+    docker manifest rm cdkbot/mayastor-$image:$TAG || true
+    docker manifest create cdkbot/mayastor-$image:$TAG --amend cdkbot/mayastor-$image:$TAG-amd64 --amend cdkbot/mayastor-$image:$TAG-arm64
+    docker manifest annotate cdkbot/mayastor-$image:$TAG cdkbot/mayastor-$image:$TAG-amd64 --arch=amd64
+    docker manifest annotate cdkbot/mayastor-$image:$TAG cdkbot/mayastor-$image:$TAG-arm64 --arch=arm64
+    docker manifest push cdkbot/mayastor-$image:$TAG
+done
+```
 
 #### Helm Chart
 
-The Helm Chart can be found at [https://github.com/canonical/mayastor](https://github.com/canonical/mayastor/tree/develop/chart)
+The Helm Chart can be found at [https://github.com/canonical/mayastor-extensions](https://github.com/canonical/mayastor/tree/develop/chart)
 
-Package any changes you make using the following commands:
+Development happens at the `v2.0.0-microk8s` mayastor branch. Releases are tagged as `v2.0.0-microk8s-INDEX`.
+
+When updating the helm chart, these are the steps to follow:
 
 ```bash
-git clone https://github.com/canonical/mayastor
-cd mayastor/chart
+git clone https://github.com/canonical/mayastor-extensions -b v2.0.0-microk8s
+cd mayastor-extensions
 
-# ... do any changes ...
+# make any adjustments to the helm chart, under the "chart/" folder
 
-# Update Helm build and repository
-helm package .
-helm repo index
+# push changes, tag new release
+git push origin v2.0.0-microk8s
+git tag v2.0.0-microk8s-1
+git push origin v2.0.0-microk8s-1
 
-# ... commit your changes ...
+# package helm chart and create index.yaml for repository
+helm package chart
+helm repo index .
 ```
 
-If the chart version of mayastor is updated, make sure to update the dependency version in [`Chart.yaml`](./Chart.yaml) as well.
+Then, create a github release from the v2.0.0-microk8s-1 tag, add the microk8s-v2.0.0-microk8s-1.tgz and index.yaml files as attachments. For an example, see https://github.com/canonical/mayastor-extensions/releases/tag/v2.0.0-microk8s-1. The changes required for MicroK8s can be seen in the diff against the upstream v2.0.0 release. See also [values.yaml](./values.yaml) with the config options we need for MicroK8s.
 
-### mayastor-control-plane
+After this is done, update [Chart.yaml](./Chart.yaml) with the new chart version, and make sure to update [Chart.lock](./Chart.lock) as well with
 
-#### Docker Image
-
-Similarly to mayastor, we need nix.
-
-1.  Install nix
-
-    ```bash
-    curl -L https://nixos.org/nix/install | sh
-    ```
-
-2.  Setup Nix environment
-
-    ```bash
-    git clone https://github.com/canonical/mayastor-control-plane
-    cd mayastor-control-plane
-    # TODO(neoaggelos): https://github.com/openebs/mayastor-control-plane/pull/242
-    git checkout
-    git submodule update --init
-    nix-shell
-    ```
-
-3.  From within the nix environment, build images. Images will be created under `/nix/store/...`, and there are symlinks `result-$x` in the current directory
-
-    ```bash
-    nix-build -A images.release
-    ```
-
-4.  Load images:
-
-    ```bash
-    for x in result*; do
-        docker load -i $x
-    done
-    ```
-
-    Example output (`mayastor-jsongrpc` image can be ignored):
-
-    ```
-    Loaded image: mayadata/mayastor-core:ea3d4501ef39
-    Loaded image: mayadata/mayastor-jsongrpc:ea3d4501ef39
-    Loaded image: mayadata/mayastor-csi-controller:ea3d4501ef39
-    Loaded image: mayadata/mayastor-csi-node:ea3d4501ef39
-    Loaded image: mayadata/mayastor-msp-operator:ea3d4501ef39
-    Loaded image: mayadata/mayastor-rest:ea3d4501ef39
-    ```
-
-5.  Tag images as cdkbot and push:
-
-    ```bash
-    for x in core csi-controller csi-node msp-operator rest; do
-        docker tag mayadata/mayastor-$x:ea3d4501ef39 cdkbot/mayastor-$x:1.0.1-microk8s-1
-        docker push cdkbot/mayastor-$x:1.0.1-microk8s-1
-    done
-    ```
-
-6.  Update the `mayastor-control-plane.mayastorCP.tag` and the image names in [`values.yaml`](./values.yaml) under the `mayastor-control-plane` section accordingly.
+```
+helm dependency update
+```

--- a/addons/mayastor/chart/TROUBLESHOOTING.md
+++ b/addons/mayastor/chart/TROUBLESHOOTING.md
@@ -1,0 +1,40 @@
+# curl: (56) OpenSSL SSL_read: Connection reset by peer, errno 104
+
+When building for arm64, lots of errors like these were encountered with multiple derivations:
+
+```
+curl: (56) OpenSSL SSL_read: Connection reset by peer, errno 104
+error: cannot download crate-nix-0.22.3.tar.gz from any mirror
+```
+
+Simply re-run the nix-build command.
+
+# Link Failed
+
+Tip: you might see an error like this:
+
+```
+/nix/store/77i6h1kjpdww9zzpvkmgyym2mz65yff1-binutils-2.35.1/bin/ld.bfd: final link failed: No space left on device
+```
+
+If `df -h` shows that the disk is in fact not full, e.g.
+```
+/dev/vda1        39G  7.0G   32G  19% /
+tmpfs           4.7G  312M  4.4G   7% /run/user/1000
+```
+
+Then you might have to increase the size of your XDG_RUNTIME_DIR (the shown tmpfs above). Note that 30% refers to your system RAM, as this is a tmpfs filesystem. To do this:
+
+```
+echo 'RuntimeDirectorySize=70%' | sudo tee -a '/etc/systemd/logind.conf'
+sudo reboot
+```
+
+Alternatively, just bind mount this to a different directory
+
+```
+mkdir ~/xdgtmp
+sudo mount --bind $XDG_RUNTIME_DIR ~/xdgtmp
+```
+
+The XDG_RUNTIME_DIR needs about 15GB to build without issues.

--- a/addons/mayastor/chart/templates/mayastor-rbac.yaml
+++ b/addons/mayastor/chart/templates/mayastor-rbac.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mayastor-daemonset-cluster-role
+  name: {{ .Values.mayastor.io_engine.serviceAccountName }}-cluster-role
 rules:
   # must create mayastor pools
   - apiGroups: ["openebs.io"]
@@ -13,13 +13,13 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mayastor-daemonset-cluster-role-binding
+  name: {{ .Values.mayastor.io_engine.serviceAccountName }}-cluster-role-binding
 subjects:
   - kind: ServiceAccount
-    name: mayastor-daemonset-service-account
+    name: {{ .Values.mayastor.io_engine.serviceAccountName | quote }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: mayastor-daemonset-cluster-role
+  name: {{ .Values.mayastor.io_engine.serviceAccountName }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
 {{ end }}

--- a/addons/mayastor/chart/templates/mayastor-sa.yaml
+++ b/addons/mayastor/chart/templates/mayastor-sa.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: mayastor-daemonset-service-account
+  name: {{ .Values.mayastor.io_engine.serviceAccountName | quote }}
   namespace: {{ .Release.Namespace }}

--- a/addons/mayastor/chart/values.yaml
+++ b/addons/mayastor/chart/values.yaml
@@ -20,6 +20,7 @@ etcd-operator:
           busyboxImage: busybox:1.28.4
           restartPolicy: Always
           hostPathVolume: "/var/snap/microk8s/common/mayastor/etcd/$NAME"
+          ClusterDomain: .cluster.local.
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -30,112 +31,109 @@ etcd-operator:
                         values: [etcd]
                   topologyKey: kubernetes.io/hostname
 
-# Mayastor Control Plane configuration
-mayastor-control-plane:
-  mayastorCP:
-    tag: 1.0.1-microk8s-2
-
-  kubeletDir: /var/snap/microk8s/common/var/lib/kubelet
-  etcdEndpoint: etcd-client
-  busyboxImage: busybox:1.28.4
-
-  base:
-    cache_poll_period: "30s"
-    default_req_timeout: "5s"
-    imagePullSecrets:
-      enabled: false
-    jaeger:
-      enabled: false
-
-  rest:
-    image: cdkbot/mayastor-rest
-    service:
-      type: ClusterIP
-  core:
-    image: cdkbot/mayastor-core
-  csi:
-    controller:
-      image: cdkbot/mayastor-csi-controller
-    node:
-      image: cdkbot/mayastor-csi-node
-      nodeSelector: []
-      driverRegistrar:
-        image: cdkbot/csi-node-driver-registrar:v2.1.0-microk8s-2
-  msp:
-    numRetries: 200
-    disableDeviceValidation: true
-    image: cdkbot/mayastor-msp-operator
-
 # Mayastor configuration
 mayastor:
-  mayastorImagesTag: 1.0.1-microk8s-2
-  mayastorImage: cdkbot/mayastor
-
-  etcdEndpoint: etcd-client
   etcd:
     enabled: false
+    externalEtcdEndpoint: "etcd-client"
 
-  nodeSelector: []
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: microk8s.io/mayastor
-                operator: NotIn
-                values: [disable]
+  obs:
+    callhome:
+      enabled: false
 
-  serviceAccountName: mayastor-daemonset-service-account
+  loki-stack:
+    enabled: false
 
-  mayastorConfigLocation: /var/snap/microk8s/common/mayastor/config
-  mayastorExtraVolumeMounts:
-    - name: data
-      mountPath: /data
-  mayastorExtraVolumes:
-    - name: data
-      hostPath:
-        type: DirectoryOrCreate
-        path: /var/snap/microk8s/common/mayastor/data
+  storageClass:
+    create: false
 
-  imageSize: 20G
-  busyboxImage: busybox:1.28.4
+  agents:
+    ha:
+      enabled: false
 
-  mayastorExtraInitContainers:
-    - name: initialize-pool
-      image: curlimages/curl:7.81.0
-      command:
-        - sh
-        - -c
-        - |
-          set -x
+  nodeSelector:
 
-          if [ -f /data/microk8s.img ]; then
-            return 0
-          fi
+  image:
+    repo: cdkbot
+    tag: v2.0.0-microk8s-1
+    pullPolicy: IfNotPresent
 
-          # create image
-          truncate -s {{ .Values.imageSize | quote }} /data/microk8s.img
+  base:
+    busyboxImage: busybox:1.28.4
+    metrics:
+      enabled: false
 
-          # create mayastorpool
-          export CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          export TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-          export BODY='{
-            "apiVersion": "openebs.io/v1alpha1",
-            "kind":"MayastorPool",
-            "metadata": {
-              "name": "microk8s-'"$(hostname)"'-pool",
-              "namespace": "'"$NAMESPACE"'"
-            },
-            "spec": {
-              "node": "'"$(hostname)"'",
-              "disks": ["/data/microk8s.img"]
-            }
-          }'
-          echo 'Creating mayastor pool'
-          curl --cacert "$CACERT" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -XPOST -d "$BODY" "https://kubernetes.default.svc/apis/openebs.io/v1alpha1/namespaces/$NAMESPACE/mayastorpools?fieldManager=kubectl-create"
-      securityContext:
-        runAsUser: 0
-      volumeMounts:
-        - name: data
-          mountPath: /data
+  csi:
+    node:
+      kubeletDir: "/var/snap/microk8s/common/var/lib/kubelet"
+
+  operators:
+    pool:
+      disableDeviceValidation: true
+      numRetries: 200
+
+  io_engine:
+    serviceAccountName: "mayastor-io-engine-sa"
+    nodeSelector:
+    configLocation: "/var/snap/microk8s/common/mayastor/config"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: microk8s.io/mayastor
+                  operator: NotIn
+                  values: [disable]
+
+    extraVolumes:
+      - name: microk8sdata
+        hostPath:
+          path: /var/snap/microk8s/common/mayastor/data
+          type: DirectoryOrCreate
+    extraVolumeMounts:
+      - name: microk8sdata
+        mountPath: /data
+
+    autoCreateImageSize: "20G"
+    extraInitContainers:
+      - name: initialize-pool
+        image: curlimages/curl:7.81.0
+        env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        command:
+          - sh
+          - -c
+          - |
+            if [ -f /data/microk8s.img ]; then
+              return 0
+            fi
+
+            # create image
+            truncate -s {{ .Values.io_engine.autoCreateImageSize | quote }} /data/microk8s.img
+
+            # create mayastorpool
+            export CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            export TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+            export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+            export BODY='{
+              "apiVersion": "openebs.io/v1alpha1",
+              "kind":"DiskPool",
+              "metadata": {
+                "name": "microk8s-'"${MY_NODE_NAME}"'-pool",
+                "namespace": "'"$NAMESPACE"'"
+              },
+              "spec": {
+                "node": "'"${MY_NODE_NAME}"'",
+                "disks": ["/data/microk8s.img"]
+              }
+            }'
+            echo 'Creating disk pool'
+            curl --cacert "$CACERT" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -XPOST -d "$BODY" "https://kubernetes.default.svc/apis/openebs.io/v1alpha1/namespaces/$NAMESPACE/diskpools?fieldManager=kubectl-create"
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: microk8sdata
+            mountPath: /data

--- a/addons/mayastor/disable
+++ b/addons/mayastor/disable
@@ -15,7 +15,7 @@ HELM = os.path.expandvars("$SNAP/microk8s-helm3.wrapper")
 MAYASTOR_DATA = pathlib.Path(os.path.expandvars("$SNAP_COMMON/mayastor/data"))
 
 
-def get_mayastorpools():
+def get_diskpools():
     """
     Return list of mayastorpools in the MicroK8s cluster.
     """
@@ -26,7 +26,7 @@ def get_mayastorpools():
     for attempt in range(5):
         try:
             pools = subprocess.check_output(
-                [KUBECTL, "get", "msp", "-n", "mayastor", "-o", "json"],
+                [KUBECTL, "get", "diskpool", "-n", "mayastor", "-o", "json"],
             )
 
             return json.loads(pools).get("items") or []
@@ -48,7 +48,7 @@ def get_mayastorpools():
 @click.option("--remove-storage/--preserve-storage", is_flag=True, default=True)
 @click.option("--force/--no-force", is_flag=True, default=True)
 def main(remove_storage: bool, force: bool):
-    pools = get_mayastorpools()
+    pools = get_diskpools()
 
     used = [p for p in pools if p.get("status", {}).get("used", 0) > 0]
     if not force and used:
@@ -60,9 +60,7 @@ def main(remove_storage: bool, force: bool):
     if remove_storage:
         for pool in pools:
             pool_name = pool["metadata"]["name"]
-            subprocess.run(
-                [DIR / "pools.py", "remove", pool_name, "--force", "--purge"]
-            )
+            subprocess.run([DIR / "pools.py", "remove", pool_name, "--force", "--purge"])
 
     subprocess.run([HELM, "uninstall", "mayastor", "-n", "mayastor"])
 

--- a/addons/mayastor/enable
+++ b/addons/mayastor/enable
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -12,6 +13,7 @@ import click
 DIR = pathlib.Path(__file__).parent.absolute()
 
 MAYASTOR_DATA = pathlib.Path(os.path.expandvars("$SNAP_COMMON/mayastor/data"))
+PLUGINS_DIR = pathlib.Path(os.path.expandvars("$SNAP_COMMON/plugins"))
 
 KUBECTL = os.path.expandvars("$SNAP/microk8s-kubectl.wrapper")
 HELM = os.path.expandvars("$SNAP/microk8s-helm3.wrapper")
@@ -156,6 +158,8 @@ Mayastor will run for all nodes in your MicroK8s cluster by default. Use the
 
 """
     )
+
+    shutil.copy(DIR / "pools.py", PLUGINS_DIR / "mayastor-pools")
 
 
 if __name__ == "__main__":

--- a/addons/mayastor/pools.py
+++ b/addons/mayastor/pools.py
@@ -97,7 +97,9 @@ def add(device: list, size: list, node: str):
     for image_size in size:
         container_path = "/data/{}.img".format(os.urandom(3).hex())
         run_on_node(node, ["truncate", "-s", str(image_size), container_path])
-        subprocess.run([KUBECTL, "apply", "-f", "-"], input=format_pool(node, container_path))
+        subprocess.run(
+            [KUBECTL, "apply", "-f", "-"], input=format_pool(node, container_path)
+        )
 
 
 @pools.command("list")


### PR DESCRIPTION
### Summary

Upgrade mayastor addon to version 2.0.0

### Changes

- Update to new helm chart https://github.com/openebs/mayastor-extensions, forked at https://github.com/canonical/mayastor-extensions. The helm chart is released at https://github.com/canonical/mayastor-extensions/releases/tag/v2.0.0-microk8s-1
- Change MayastorPool references to DiskPool (change in mayastor 2.0.0)
- Update addon build instructions for new helm charts, fix build instructions, add troubleshooting tips and add instructions for multi-arch images
- Adjust values.yaml file for the new helm chart
- Add a `microk8s mayastor-pools` helper command that can be used to easily manage pools in the cluster.