### PR TITLE
Fix kubeovn conflict for Microk8s 1.27

### DIFF
--- a/addons/kube-ovn/kube-ovn.yaml
+++ b/addons/kube-ovn/kube-ovn.yaml
@@ -156,7 +156,17 @@ spec:
         - name: install-cni
           image: "kubeovn/kube-ovn:v1.10.0"
           imagePullPolicy: IfNotPresent
-          command: ["/kube-ovn/install-cni.sh"]
+          command:
+            - bash
+            - -x
+            - -c
+            - |
+              # remove conflicting cni binaries
+              rm -fv /opt/cni/bin/portmap
+              rm -fv /opt/cni/bin/loopback
+              rm -fv /opt/cni/bin/macvlan
+
+              /kube-ovn/install-cni.sh
           securityContext:
             runAsUser: 0
             privileged: true


### PR DESCRIPTION
### Summary

Fixes this KubeOVN issue with latest 1.27 candidate builds:

```
cp: not writing through dangling symlink '/opt/cni/bin/$binary'
```