### PR TITLE
retry mayastor disk pool creation in case of failures

### DIFF
--- a/addons/mayastor/chart/values.yaml
+++ b/addons/mayastor/chart/values.yaml
@@ -131,7 +131,10 @@ mayastor:
               }
             }'
             echo 'Creating disk pool'
-            curl --cacert "$CACERT" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -XPOST -d "$BODY" "https://kubernetes.default.svc/apis/openebs.io/v1alpha1/namespaces/$NAMESPACE/diskpools?fieldManager=kubectl-create"
+            while ! curl --fail --cacert "$CACERT" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -XPOST -d "$BODY" "https://kubernetes.default.svc/apis/openebs.io/v1alpha1/namespaces/$NAMESPACE/diskpools?fieldManager=kubectl-create"; do
+              echo 'Creating disk pool failed, will retry'
+              sleep 5
+            done
         securityContext:
           runAsUser: 0
         volumeMounts:


### PR DESCRIPTION
### Summary

Fixes

```
Creating disk pool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   307  100    19  100   288   1243  18842 --:--:-- --:--:-- --:--:-- 20466
404 page not found
```

The curl call might fail if the io-engine pods come up before the disk pool operator, since the diskpool operator is the entity that defines the diskpool CRD.