### PR TITLE
Update mayastor addon to pass correct value to helm chart for image size

### DIFF
--- a/addons/mayastor/enable
+++ b/addons/mayastor/enable
@@ -119,7 +119,7 @@ def main(
         args.extend(["--set", "storageClass.create=false"])
     if default_pool_size:
         click.echo("Default image size set to {}".format(default_pool_size))
-        args.extend(["--set", "mayastor.imageSize={}".format(default_pool_size)])
+        args.extend(["--set", "mayastor.io_engine.autoCreateImageSize={}".format(default_pool_size)])
 
     # Fetch dependencies
     subprocess.check_call([HELM, "dependency", "update"], cwd=DIR / "chart")


### PR DESCRIPTION
Updated addon to pass correct value to [helm chart](https://github.com/canonical/microk8s-core-addons/blob/99954f9175615397ee12f6a1c4d4a9b2c6606cd2/addons/mayastor/chart/values.yaml#L115) for image size.