### PR TITLE
Fix formatting of cert-manager addon enable script

### DIFF
--- a/addons/cert-manager/enable
+++ b/addons/cert-manager/enable
@@ -54,7 +54,7 @@ EOF
 Then, you can create an ingress to expose 'my-service:80' on 'https://my-service.example.com' with:
 
 $ microk8s enable ingress
-$ microk8s kubectl create ingress my-ingress \
-    --annotation cert-manager.io/cluster-issuer=letsencrypt \
+$ microk8s kubectl create ingress my-ingress \\
+    --annotation cert-manager.io/cluster-issuer=letsencrypt \\
     --rule 'my-service.example.com/*=my-service:80,tls=my-service-tls'
 "


### PR DESCRIPTION
### Summary

No functional changes. Fixes the following output:

```bash
Then, you can create an ingress to expose 'my-service:80' on 'https://my-service.example.com' with:

$ microk8s enable ingress
$ microk8s kubectl create ingress my-ingress     --annotation cert-manager.io/cluster-issuer=letsencrypt     --rule 'my-service.example.com/*=my-service:80,tls=my-service-tls'
```

to:

```bash
Then, you can create an ingress to expose 'my-service:80' on 'https://my-service.example.com' with:

$ microk8s enable ingress
$ microk8s kubectl create ingress my-ingress \
    --annotation cert-manager.io/cluster-issuer=letsencrypt \
    --rule 'my-service.example.com/*=my-service:80,tls=my-service-tls'
```