### PR TITLE
CIS tokens patch

### DIFF
--- a/addons/cis-hardening/disable
+++ b/addons/cis-hardening/disable
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import subprocess
+
 import click
 
 DIR = pathlib.Path(__file__).parent.absolute()

--- a/addons/cis-hardening/disable
+++ b/addons/cis-hardening/disable
@@ -68,7 +68,8 @@ def RemoveExtraConfigFiles():
     """Remove the extra configuration files placed under the args directory."""
     click.echo("Remove extra configuration files")
     for f in [ "admission-control-config-file.yaml", "eventconfig.yaml", "audit-policy.yaml"]:
-        os.remove(ARGS_DIR / f )
+        if os.path.exists(f):
+            os.remove(ARGS_DIR / f )
 
 
 def RemoveServiceArguments():
@@ -111,12 +112,7 @@ def RemoveServiceArguments():
         res = removeArgument(arg, "kubelet")
         restart = restart or res
 
-    if restart:
-        try:
-            subprocess.call("snapctl services microk8s.daemon-kubelite".split())
-        except subprocess.CalledProcessError as e:
-            click.echo(f"Failed to restart kubelite: {e}", err=True)
-            exit(4)
+    return restart
 
 
 def NeedsRoot():
@@ -144,12 +140,56 @@ def UninstallKubebench():
          click.echo(f"Failed to remove kube-bench: {e}", err=True)
 
 
+def UndoTokens():
+    """Remove tokens patches"""
+    if not os.path.exists(CREDS_DIR / "client.config.tokens.backup"):
+        return False
+
+    click.echo("Reverting to tokens auth")
+    files = [
+        (CREDS_DIR / "kubelet.config.tokens.backup", CREDS_DIR / "kubelet.config"),
+        (CREDS_DIR / "proxy.config.tokens.backup", CREDS_DIR / "proxy.config"),
+        (CREDS_DIR / "scheduler.config.tokens.backup", CREDS_DIR / "scheduler.config"),
+        (CREDS_DIR / "controller.config.tokens.backup", CREDS_DIR / "controller.config"),
+        (CREDS_DIR / "client.config.tokens.backup", CREDS_DIR / "client.config"),
+    ]
+
+    for file in files:
+        if os.path.exists(file[0]):
+            os.replace(file[0], file[1])
+
+    files = [ "admin", "system:kube-controller-manager", "system:kube-proxy", "system:kube-scheduler" ]
+    for file in files:
+        for ext in [ "crt", "key", "csr" ]:
+            f = CERTS_DIR / f"{file}.{ext}"
+            if os.path.exists(f):
+                os.remove(f)
+
+    with open(ARGS_DIR / "kube-apiserver", "a+") as file_object:
+        file_object.write("--token-auth-file=${SNAP_DATA}/credentials/known_tokens.csv\n")
+
+    return True
+
+
+def Restart():
+    click.echo("Restarting kubelet")
+    try:
+        subprocess.call("snapctl services microk8s.daemon-kubelite".split())
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Failed to restart kubelite: {e}", err=True)
+        exit(4)
+
+
 @click.command()
 def main():
     NeedsRoot()
-    RemoveServiceArguments()
+    restart = False
+    restart = RemoveServiceArguments()
     RemoveExtraConfigFiles()
     UndoFilePermissions()
+    restart = UndoTokens() or restart
+    if restart:
+        Restart()        
     UninstallKubebench()
     MarkAddonDisabled()
 

--- a/addons/cis-hardening/enable
+++ b/addons/cis-hardening/enable
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import os
-import csv
 import base64
+import csv
+import os
 import pathlib
+import platform
 import shutil
 import subprocess
-import platform
-import requests
 
 import click
+import requests
 
 DIR = pathlib.Path(__file__).parent.absolute()
 PLUGINS_DIR = pathlib.Path(os.path.expandvars("$SNAP_COMMON/plugins"))

--- a/addons/cis-hardening/enable
+++ b/addons/cis-hardening/enable
@@ -44,16 +44,16 @@ def create_x509_kubeconfig(filename, user, path_to_cert, path_to_cert_key):
     if os.path.exists(config):
         shutil.copyfile(config, "{}.tokens.backup".format(config))
     
-    with open(CERTS_DIR / "ca.crt", "r") as caf:
-        ca = caf.read()
+    with open(CERTS_DIR / "ca.crt", "r") as f:
+        ca = f.read()
         ca_line = base64.b64encode(ca.encode("utf-8")).decode("utf-8")
 
-    with open(path_to_cert, "r") as caf:
-        cert = caf.read()
+    with open(path_to_cert, "r") as f:
+        cert = f.read()
         cert_line = base64.b64encode(cert.encode("utf-8")).decode("utf-8")
 
-    with open(path_to_cert_key, "r") as caf:
-        cert = caf.read()
+    with open(path_to_cert_key, "r") as f:
+        cert = f.read()
         key_line = base64.b64encode(cert.encode("utf-8")).decode("utf-8")
 
     with open(config_template, "r") as tfp:

--- a/addons/cis-hardening/enable
+++ b/addons/cis-hardening/enable
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import os
+import csv
+import base64
 import pathlib
 import shutil
 import subprocess
@@ -25,6 +27,107 @@ def isStrict():
             if "confinement" in line and "strict" in line:
                 return True
     return False
+
+
+def create_x509_kubeconfig(filename, user, path_to_cert, path_to_cert_key):
+    """
+    Create a kubeconfig file. The file in stored under credentials named after the user
+
+    :param filename: the name of the config file
+    :param user: the user to use al login
+    :param path_to_cert: path to certificate file
+    :param path_to_cert_key: path to certificate key file
+    """
+    snap_path = pathlib.Path(os.environ.get("SNAP"))
+    config_template = snap_path / "client-x509.config.template"
+    config = CREDS_DIR / filename
+    if os.path.exists(config):
+        shutil.copyfile(config, "{}.tokens.backup".format(config))
+    
+    with open(CERTS_DIR / "ca.crt", "r") as caf:
+        ca = caf.read()
+        ca_line = base64.b64encode(ca.encode("utf-8")).decode("utf-8")
+
+    with open(path_to_cert, "r") as caf:
+        cert = caf.read()
+        cert_line = base64.b64encode(cert.encode("utf-8")).decode("utf-8")
+
+    with open(path_to_cert_key, "r") as caf:
+        cert = caf.read()
+        key_line = base64.b64encode(cert.encode("utf-8")).decode("utf-8")
+
+    with open(config_template, "r") as tfp:
+        with open(config, "w+") as fp:
+            config_txt = tfp.read()
+            config_txt = config_txt.replace("CADATA", ca_line)
+            config_txt = config_txt.replace("NAME", user)
+            config_txt = config_txt.replace("PATHTOCERT", cert_line)
+            config_txt = config_txt.replace("PATHTOKEYCERT", key_line)
+            config_txt = config_txt.replace("client-certificate", "client-certificate-data",)
+            config_txt = config_txt.replace("client-key", "client-key-data")
+            fp.write(config_txt)
+
+
+def create_certificate(name, group):
+    snap_path = pathlib.Path(os.environ.get("SNAP"))
+    cert = CERTS_DIR / f"{name}.crt"
+    key = CERTS_DIR / f"{name}.key"
+    csr = CERTS_DIR / f"{name}.csr"
+    cacert = CERTS_DIR / "ca.crt"
+    cakey = CERTS_DIR / "ca.key"
+    
+    try:
+        cmd = f"{snap_path}/usr/bin/openssl genrsa -out {key} 2048"
+        subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        cmd = f"{snap_path}/usr/bin/openssl req -new -key {key} -out {csr} -subj /CN={name}"
+        if group:
+            cmd += f"/O={group}"
+        subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        cmd = f"{snap_path}/usr/bin/openssl x509 -req -in {csr} -CA {cacert} -CAkey {cakey} -CAcreateserial -out {cert} -days 3650"
+        subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return (cert, key)
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Failed to generate certificates: {e}", err=True)
+        exit(6)
+
+
+def FixTokens():
+    """Configure node to not use token authentication"""
+    tokens = False
+    lines = []
+    with open(ARGS_DIR / "kube-apiserver", "r") as file:
+        for line_number, line in enumerate(file, start=1):
+            if line.startswith("--token-auth-file"):
+                tokens = True
+                continue
+            lines.append(line)
+    if not tokens:
+        return False
+    
+    click.echo("Removing tokens")
+    entities = [
+        {"username": "admin", "group":"system:masters", "filename": "client.config"},
+        {"username": "system:kube-controller-manager", "group": None, "filename": "controller.config"},
+        {"username": "system:kube-proxy", "group": None, "filename": "proxy.config"},
+        {"username": "system:kube-scheduler", "group": None, "filename": "scheduler.config"},
+    ]
+
+    with open(CREDS_DIR / "known_tokens.csv") as tokens_file:
+        tokens_reader = csv.reader(tokens_file, delimiter=',')
+        for row in tokens_reader:
+            if row[2].startswith("kubelet"):
+                entities.append(
+                    {"username": row[1], "group": "system:nodes", "filename": "kubelet.config"}
+                )
+                break
+
+    for entity in entities:
+        cert,key = create_certificate(entity["username"], entity["group"])
+        create_x509_kubeconfig(filename=entity["filename"], user=entity["username"], path_to_cert=cert, path_to_cert_key=key)
+
+    with open(ARGS_DIR / "kube-apiserver", "w+") as file:
+        file.writelines(lines)
+    return True
 
 
 def FixFilePermissions():
@@ -110,12 +213,16 @@ def SetServiceArguments():
         res = addArgument(arg[0], arg[1], "kubelet")
         restart = restart or res
 
-    if restart:
-        try:
-            subprocess.call("snapctl services microk8s.daemon-kubelite".split())
-        except subprocess.CalledProcessError as e:
-            click.echo(f"Failed to restart kubelite: {e}", err=True)
-            exit(4)
+    return restart
+
+
+def Restart():
+    click.echo("Restarting kubelet")
+    try:
+        subprocess.call("snapctl services microk8s.daemon-kubelite".split())
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Failed to restart kubelite: {e}", err=True)
+        exit(4)
 
 
 def EnableRBAC():
@@ -161,7 +268,7 @@ def DownloadKubebench(kubebench_version: str):
         open(tarball, "wb").write(response.content)
         if not os.path.exists(kubebench):
             os.mkdir(kubebench)
-        subprocess.check_call(f"{tarbin} -vzxf {tarball}  --no-same-owner -C {kubebench}".split())
+        subprocess.check_call(f"{tarbin} -zxf {tarball}  --no-same-owner -C {kubebench}".split())
         src = DIR / "kube-bench"
         dst = PLUGINS_DIR / "kube-bench"
         shutil.copyfile(src, dst)
@@ -207,7 +314,10 @@ def main(kubebench_version: str):
     CopyExtraConfigFiles()
     DownloadKubebench(kubebench_version)
     FixFilePermissions()
-    SetServiceArguments()
+    args_restart = SetServiceArguments()
+    token_restart = FixTokens()
+    if args_restart or token_restart:
+        Restart()
     MarkAddonEnabled()
     PrintExitMessage()
 

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -437,10 +437,10 @@ def validate_cis_hardening():
     print(output)
     assert "42 checks WARN" in output
     if os.environ.get("STRICT") == "yes":
-        assert "73 checks PASS" in output
-        assert "2 checks FAIL" in output
+        assert "74 checks PASS" in output
+        assert "1 checks FAIL" in output
     else:
         # The extra test that is failing on strict is the permissions of the
         # systemd kubelite service definition
-        assert "74 checks PASS" in output
-        assert "1 checks FAIL" in output
+        assert "75 checks PASS" in output
+        assert "0 checks FAIL" in output


### PR DESCRIPTION
This PR enables the CIS addon to switch away from the tokens based auth.

The work on the enable/disable hooks will not run on 1.28 snap as that snap will ship without token auth by default. The work on the hooks is only relevant to snaps that got refreshed to the 1.28 version.  

This PR also includes updates on the README on how to configure a pre 1.28 node not to use auth tokens.