### PR TITLE
Flag to skip kubebench download and install in cis hardening

### DIFF
--- a/addons/cis-hardening/README.md
+++ b/addons/cis-hardening/README.md
@@ -11,8 +11,10 @@ microk8s enable cis-hardening
 ```
 
 The addon assumes a default configuration and reconfigures the MicroK8s services to comply with the CIS-1.24 recommendations.
-Enabling the addon also installs kube-bench as a plugin along with a revised version of CIS benchmark configurations applicable for MicroK8s.
-Call kube-bench with:
+
+
+Unless the `--install-kubebench` flag is set to `false`, enabling the addon also installs kube-bench as a plugin along with
+a revised version of CIS benchmark configurations applicable for MicroK8s. Call kube-bench with:
 
 ```
 sudo microk8s kube-bench

--- a/addons/cis-hardening/enable
+++ b/addons/cis-hardening/enable
@@ -183,19 +183,22 @@ def MarkAddonEnabled():
     pathlib.Path(lockfile).touch()
 
 
-def PrintExitMessage():
+def PrintExitMessage(install_kubebench):
     """Print info at the end of enabling the addon."""
     click.echo()
-    click.echo("CIS hardening configuration has been applied and kube-bench is installed as a plugin.")
-    click.echo("All microk8s commands require sudo from now on. Inspect the CIS benchmark results with:")
-    click.echo()
-    click.echo("  sudo microk8s kube-bench")
+    click.echo("CIS hardening configuration has been applied. All microk8s commands require sudo from now on.")
+    click.echo("Remember to enable this addon on nodes joining the custer.")
+    if install_kubebench:
+        click.echo("Inspect the CIS benchmark results with:")
+        click.echo()
+        click.echo("  sudo microk8s kube-bench")
     click.echo()
 
 
 @click.command()
 @click.option("--kubebench-version", default="0.6.13")
-def main(kubebench_version: str):
+@click.option("--install-kubebench", default=True)
+def main(kubebench_version: str, install_kubebench):
     """
     The entry point to the enable script.
 
@@ -205,11 +208,12 @@ def main(kubebench_version: str):
     NeedsRoot()
     EnableRBAC()
     CopyExtraConfigFiles()
-    DownloadKubebench(kubebench_version)
+    if install_kubebench:
+        DownloadKubebench(kubebench_version)
     FixFilePermissions()
     SetServiceArguments()
     MarkAddonEnabled()
-    PrintExitMessage()
+    PrintExitMessage(install_kubebench)
 
 
 if __name__ == '__main__':

--- a/addons/cis-hardening/enable
+++ b/addons/cis-hardening/enable
@@ -161,7 +161,7 @@ def DownloadKubebench(kubebench_version: str):
         open(tarball, "wb").write(response.content)
         if not os.path.exists(kubebench):
             os.mkdir(kubebench)
-        subprocess.check_call(f"{tarbin} -vzxf {tarball}  --no-same-owner -C {kubebench}".split())
+        subprocess.check_call(f"{tarbin} -zxf {tarball}  --no-same-owner -C {kubebench}".split())
         src = DIR / "kube-bench"
         dst = PLUGINS_DIR / "kube-bench"
         shutil.copyfile(src, dst)


### PR DESCRIPTION
This PR introduces a `--install-kubebench` flag that skips the installation of kubebench. This is useful in offline deployments.