### PR TITLE
Add rook-ceph addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -206,3 +206,11 @@ microk8s-addons:
       supported_architectures:
         - amd64
         - arm64
+
+    - name: "rook-ceph"
+      version: "1.11.3"
+      description: "Rook Ceph storage operator"
+      check_status: "deployment.apps/rook-ceph-operator"
+      supported_architectures:
+        - amd64
+        - arm64

--- a/addons/rook-ceph/disable
+++ b/addons/rook-ceph/disable
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import subprocess
+
+import click
+
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+KUBECTL = SNAP / "microk8s-kubectl.wrapper"
+
+
+@click.command()
+def main():
+    destination_dir = "/tmp/rook"
+    example_manifest_dir = destination_dir + "/deploy/examples/"
+    operator_manifest = example_manifest_dir + "operator.yaml"
+    crds_manifest = example_manifest_dir + "crds.yaml"
+    common_manifest = example_manifest_dir + "common.yaml"
+
+    # Delete the CRDs, common and operator
+    subprocess.run([KUBECTL, "delete", "-f", crds_manifest, "-f", common_manifest, "-f", operator_manifest])
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/rook-ceph/disable
+++ b/addons/rook-ceph/disable
@@ -7,12 +7,13 @@ import subprocess
 import click
 
 SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA") or "/var/snap/microk8s/current")
 KUBECTL = SNAP / "microk8s-kubectl.wrapper"
 
 
 @click.command()
 def main():
-    destination_dir = "/tmp/rook"
+    destination_dir = str(SNAP_DATA) + "/tmp/rook"
     example_manifest_dir = destination_dir + "/deploy/examples/"
     operator_manifest = example_manifest_dir + "operator.yaml"
     crds_manifest = example_manifest_dir + "crds.yaml"
@@ -20,6 +21,9 @@ def main():
 
     # Delete the CRDs, common and operator
     subprocess.run([KUBECTL, "delete", "-f", crds_manifest, "-f", common_manifest, "-f", operator_manifest])
+
+    # remove the rook-ceph repository
+    subprocess.run(["rm", "-rf", destination_dir])
 
 
 if __name__ == "__main__":

--- a/addons/rook-ceph/enable
+++ b/addons/rook-ceph/enable
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import subprocess
+
+import click
+
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+KUBECTL = SNAP / "microk8s-kubectl.wrapper"
+
+
+def clone_repository(repo_url, destination_dir, branch):
+    """
+    Clone a particular branch of a git repository to a destination directory.
+
+    :param repo_url: The repository URL.
+    :param destination_dir: The destination directory.
+    :param branch: The branch to clone.
+    """
+    click.echo(f"Cloning repository version {branch} in {destination_dir}")
+    try:
+        subprocess.call("git clone {} {} -b {}".format(repo_url, destination_dir, branch).split())
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Failed to clone repo: {e}", err=True)
+        exit(4)
+
+
+def update_manifest(file_path, old_path, new_path):
+    """
+    Change the path in a manifest file from old_path to new_path.
+
+    :param file_path: The path to the manifest file.
+    :param old_path: The old path to replace.
+    :param new_path: The new path to use.
+    """
+    click.echo(f"Updating {file_path} to use {new_path} instead of {old_path}")
+    try:
+        with open(file_path, "r+") as file:
+            content = file.read()
+            content = content.replace(old_path, new_path)
+            file.seek(0)
+            file.write(content)
+            file.truncate()
+    except (OSError, IndexError, ValueError) as e:
+        click.echo(f"Failed to update operator.yaml: {e}", err=True)
+        exit(4)
+
+
+@click.command()
+@click.option("--rook-version", default="v1.11.3")
+def main(rook_version: str):
+    rook_repo_url = "https://github.com/rook/rook"
+    destination_dir = "/tmp/rook"
+    example_manifest_dir = destination_dir + "/deploy/examples/"
+    operator_manifest = example_manifest_dir + "operator.yaml"
+    crds_manifest = example_manifest_dir + "crds.yaml"
+    common_manifest = example_manifest_dir + "common.yaml"
+    old_path = "/var/lib/kubelet"
+    new_path = "/var/snap/microk8s/common/var/lib/kubelet"
+
+    # Clone the rook-ceph repository
+    clone_repository(rook_repo_url, destination_dir, rook_version)
+
+    # Update the operator manifest to use the correct path for the kubelet
+    update_manifest(operator_manifest, old_path, new_path)
+
+    # Create the CRDs, common and operator
+    subprocess.run([KUBECTL, "create", "-f", crds_manifest, "-f", common_manifest, "-f", operator_manifest])
+
+    click.echo(
+        f"""
+============================================================
+
+INFO: Rook Ceph is now enabled.
+
+Rook provides `create-external-cluster-resources.py` and `import-external-cluster.sh` 
+scripts to create all the necessary resources for an external cluster.
+If you want to use an external Ceph cluster, please follow the instructions below:
+
+# Go to the rook examples directory
+$ cd path/to/rook/deploy/examples
+
+# deploy rbac rules
+$ kubectl create -f common-external.yaml
+
+# create and initialize an rbd pool
+$ ceph osd pool create rbd0
+$ rbd pool init rbd0
+
+# assuming ceph config file and user is available, creates all ceph clients and configurations
+$ ./create-external-cluster-resources.py --format bash --output config.rc
+
+# source configuration and deploy cluster resources
+$ . config.rc
+$ . ./import-external-cluster.sh
+
+# create external cluster resource, will pick up the configs/secrets deployed previously
+$ kubectl create -f cluster-external.yaml
+=============================================================
+"""
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/rook-ceph/enable
+++ b/addons/rook-ceph/enable
@@ -6,8 +6,8 @@ import subprocess
 
 import click
 
-SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
-SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA") or "/var/snap/microk8s/current")
+SNAP = pathlib.Path(os.getenv("SNAP"))
+SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA"))
 KUBECTL = SNAP / "microk8s-kubectl.wrapper"
 
 def download_source_repo(destination_dir, version):
@@ -82,7 +82,7 @@ scripts to create all the necessary resources for an external cluster.
 If you want to use an external Ceph cluster, please follow the instructions below:
 
 # Go to the rook examples directory
-$ cd ${SNAP_DATA}/rook/deploy/examples
+$ cd /var/snap/microk8s/current/tmp/rook/deploy/examples
 
 # deploy rbac rules
 $ microk8s.kubectl create -f common-external.yaml

--- a/addons/rook-ceph/enable
+++ b/addons/rook-ceph/enable
@@ -7,33 +7,39 @@ import subprocess
 import click
 
 SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA") or "/var/snap/microk8s/current")
 KUBECTL = SNAP / "microk8s-kubectl.wrapper"
 
-
-def clone_repository(repo_url, destination_dir, branch):
+def download_source_repo(destination_dir, version):
     """
-    Clone a particular branch of a git repository to a destination directory.
+    Download source code artifact to a destination directory.
 
-    :param repo_url: The repository URL.
     :param destination_dir: The destination directory.
-    :param branch: The branch to clone.
+    :param version: The version of the source code artifact.
     """
-    click.echo(f"Cloning repository version {branch} in {destination_dir}")
+    click.echo(f"Downloading rook version {version} in {destination_dir}")
     try:
-        subprocess.call("git clone {} {} -b {}".format(repo_url, destination_dir, branch).split())
+        # Download the repo in a temp directory.
+        temp_dir = str(SNAP_DATA) + "/tmp"
+        os.makedirs(temp_dir, exist_ok=True)
+        subprocess.call("curl -sL -o {}/rook.tar.gz https://github.com/rook/rook/archive/refs/tags/{}.tar.gz".format(temp_dir, version).split())
+
+        subprocess.call("tar -xzf {}/rook.tar.gz --one-top-level={} --strip-components=1".format(temp_dir, destination_dir).split())
+
+        os.remove("{}/rook.tar.gz".format(temp_dir))
     except subprocess.CalledProcessError as e:
-        click.echo(f"Failed to clone repo: {e}", err=True)
+        click.echo(f"Failed to download repo: {e}", err=True)
         exit(4)
 
 
-def update_manifest(file_path, old_path, new_path):
+def update_manifest(file_path):
     """
     Change the path in a manifest file from old_path to new_path.
 
     :param file_path: The path to the manifest file.
-    :param old_path: The old path to replace.
-    :param new_path: The new path to use.
     """
+    old_path = "/var/lib/kubelet"
+    new_path = "/var/snap/microk8s/common/var/lib/kubelet"
     click.echo(f"Updating {file_path} to use {new_path} instead of {old_path}")
     try:
         with open(file_path, "r+") as file:
@@ -50,20 +56,17 @@ def update_manifest(file_path, old_path, new_path):
 @click.command()
 @click.option("--rook-version", default="v1.11.3")
 def main(rook_version: str):
-    rook_repo_url = "https://github.com/rook/rook"
-    destination_dir = "/tmp/rook"
+    destination_dir = str(SNAP_DATA) + "/tmp/rook"
     example_manifest_dir = destination_dir + "/deploy/examples/"
     operator_manifest = example_manifest_dir + "operator.yaml"
     crds_manifest = example_manifest_dir + "crds.yaml"
     common_manifest = example_manifest_dir + "common.yaml"
-    old_path = "/var/lib/kubelet"
-    new_path = "/var/snap/microk8s/common/var/lib/kubelet"
 
-    # Clone the rook-ceph repository
-    clone_repository(rook_repo_url, destination_dir, rook_version)
+    # Download the rook-ceph repository
+    download_source_repo(destination_dir, rook_version)
 
     # Update the operator manifest to use the correct path for the kubelet
-    update_manifest(operator_manifest, old_path, new_path)
+    update_manifest(operator_manifest)
 
     # Create the CRDs, common and operator
     subprocess.run([KUBECTL, "create", "-f", crds_manifest, "-f", common_manifest, "-f", operator_manifest])
@@ -79,10 +82,10 @@ scripts to create all the necessary resources for an external cluster.
 If you want to use an external Ceph cluster, please follow the instructions below:
 
 # Go to the rook examples directory
-$ cd path/to/rook/deploy/examples
+$ cd ${SNAP_DATA}/rook/deploy/examples
 
 # deploy rbac rules
-$ kubectl create -f common-external.yaml
+$ microk8s.kubectl create -f common-external.yaml
 
 # create and initialize an rbd pool
 $ ceph osd pool create rbd0
@@ -96,7 +99,7 @@ $ . config.rc
 $ . ./import-external-cluster.sh
 
 # create external cluster resource, will pick up the configs/secrets deployed previously
-$ kubectl create -f cluster-external.yaml
+$ microk8s.kubectl create -f cluster-external.yaml
 =============================================================
 """
     )

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -23,6 +23,7 @@ from validators import (
     validate_mayastor,
     validate_cert_manager,
     validate_cis_hardening,
+    validate_rook_ceph,
 )
 from utils import (
     microk8s_enable,
@@ -347,3 +348,14 @@ class TestAddons(object):
 
         # Remove labels
         kubectl(f"label node {node_name} pvc-node-name-")
+
+    def test_rook_ceph_addon(self):
+        """
+        Test Rook Ceph.
+        """
+        print("Enabling Rook Ceph")
+        microk8s_enable("rook-ceph")
+        print("Validating Rook Ceph")
+        validate_rook_ceph()
+        print("Disabling Rook Ceph")
+        microk8s_disable("rook-ceph")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -466,3 +466,11 @@ def validate_cis_hardening():
         # systemd kubelite service definition
         assert "83 checks PASS" in output
         assert "0 checks FAIL" in output
+
+
+def validate_rook_ceph():
+    """
+    Validate rook-ceph. Wait for rook-ceph operator to come up.
+    """
+    wait_for_installation()
+    wait_for_pod_state("", "rook-ceph", "running", label="app=rook-ceph-operator")


### PR DESCRIPTION
#### Summary
This pull request is the first step that adds support for distributed and high-availability storage on MicroK8s clusters using Rook Ceph. This is done to allow users to consume external Ceph clusters deployed using Ceph, MicroCeph, or any other tool. To enable Ceph support on MicroK8s, the user needs to deploy the Rook Ceph operator by running the following command:
```
microk8s enable rook-ceph --rook-version=1.xx.x
```
Currently, this will deploy the rook operator and print a message to follow up on the next steps.

To disable the addon:
```
microk8s disable rook-ceph
```
