### PR TITLE
Add kubelet-cert-authority as default

### DIFF
--- a/addons/cis-hardening/disable
+++ b/addons/cis-hardening/disable
@@ -81,8 +81,7 @@ def RemoveExtraConfigFiles():
 def RemoveServiceArguments():
     """Remove arguments from all services."""
     click.echo("Setting API server arguments")
-    args = ["--kubelet-certificate-authority",
-            "--enable-admission-plugins",
+    args = ["--enable-admission-plugins",
             "--admission-control-config-file",
             "--audit-log-path",
             "--audit-log-maxage",


### PR DESCRIPTION
Summary
Add the argument --kubelet-certificate-authority as default in kube api-server.

Testing
Tested locally by building the snap and enabling and disabling CIS addon.

Related PR: https://github.com/canonical/microk8s/pull/4044
