### PR TITLE
Add MetalLB in FRR mode via flags, add webhookvalidation disable option

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 **/addons/ingress/ingress.yaml
 **/addons/metallb/metallb.yaml
+**/addons/metallb/metallb-frr.yaml
 **/addons/metallb/addresspool.yaml
 **/addons/cert-manager/cert-manager.yaml
 **/addons/kube-ovn/ovn-template.yaml

--- a/addons/metallb/disable
+++ b/addons/metallb/disable
@@ -12,4 +12,7 @@ $KUBECTL delete -f $CURRENT_DIR/crd.yaml
 
 $KUBECTL delete namespaces metallb-system
 
+# Due to the Webhook Configuration not being namespaced, we have to remove it manually
+$KUBECTL delete validatingwebhookconfiguration.admissionregistration.k8s.io/metallb-webhook-configuration
+
 echo "MetalLB is terminated"

--- a/addons/metallb/enable
+++ b/addons/metallb/enable
@@ -9,6 +9,56 @@ KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 
 echo "Enabling MetalLB"
 
+read -ra METALLB_ARGUMENTS <<< "$2"
+if [ -z "${METALLB_ARGUMENTS[@]}" ]
+then
+  echo "Do you want to install MetalLB in frr-mode (required for IPv6 BGP peering)?"
+  echo "You can also pass 'frr' as an argument to enable frr when enabling this addon: "
+  echo " microk8s enable metallb:192.168.1.240/24:frr"
+  read -p "(Yes/No): " answer
+  answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
+  if [ "$answer" = "yes" ]; then
+    FRR_MODE=true
+  else
+    FRR_MODE=false
+  fi
+else
+  argument="${METALLB_ARGUMENTS[@]}"
+  if [ "$argument" = "frr" ]; then
+    FRR_MODE=true
+  else
+    FRR_MODE=false
+  fi
+fi
+echo "FRR-mode enabled: $FRR_MODE"
+
+
+# Due to a bug in metallb, sometimes, the cert configuration
+# for the validation endpoints is broken after deployment.
+# As this happens seemingly at random, the option to disable
+# them is provided. This is only a temporary fix, until the
+# real issue is fixed upstream. See Issue #1597 at github.com/metallb
+# for more information about this
+
+read -ra DISABLE_WEBHOOK_SAFETY_ARGUMENTS <<< "$3"
+if [ -z "${DISABLE_WEBHOOK_SAFETY_ARGUMENTS[@]}" ]
+then
+  echo "Setting Webhook Policy to 'Fail'"
+  WEBHOOK_FAILURE_POLICY="Fail"
+else
+  argument="${DISABLE_WEBHOOK_SAFETY_ARGUMENTS[@]}"
+  if [ "$argument" = "ignore" ]; then
+    WEBHOOK_FAILURE_POLICY="Ignore"
+    echo "The Webhook failure policy has been set to 'ignore'!"
+    echo "This can be dangerous, as it enables the kube-api to"
+    echo "potentially deploy invalid manifests, proceed with caution!"
+  else
+    WEBHOOK_FAILURE_POLICY="Fail"
+  fi
+  echo "Webhook Failure Policy: $WEBHOOK_FAILURE_POLICY"
+fi
+
+
 ALLOWESCALATION=false
 if grep  -e ubuntu /proc/version | grep 16.04 &> /dev/null
 then
@@ -47,7 +97,12 @@ done
 echo "Applying Metallb manifest"
 $KUBECTL apply -f $CURRENT_DIR/crd.yaml
 
-cat $CURRENT_DIR/metallb.yaml | $SNAP/bin/sed "s@{{allow_escalation}}@$ALLOWESCALATION@g" | $KUBECTL apply -f -
+if [ "$FRR_MODE" = true ] ; then
+  cat $CURRENT_DIR/metallb-frr.yaml | $SNAP/bin/sed "s@{{allow_escalation}}@$ALLOWESCALATION@g" | $SNAP/bin/sed "s@failurePolicy: Fail@failurePolicy: \"$WEBHOOK_FAILURE_POLICY\"@g" | $KUBECTL apply -f -
+else
+  cat $CURRENT_DIR/metallb.yaml | $SNAP/bin/sed "s@{{allow_escalation}}@$ALLOWESCALATION@g" | $SNAP/bin/sed "s@failurePolicy: Fail@failurePolicy: \"$WEBHOOK_FAILURE_POLICY\"@g" | $KUBECTL apply -f -
+fi
+
 
 echo "Waiting for Metallb controller to be ready."
 while ! $KUBECTL -n metallb-system  wait deployment controller --for condition=Available=True --timeout=30s ; do

--- a/addons/metallb/metallb-frr.yaml
+++ b/addons/metallb/metallb-frr.yaml
@@ -402,10 +402,83 @@ spec:
         component: speaker
     spec:
       containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              /sbin/tini -- /usr/lib/frr/docker-start &
+              attempts=0
+              until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
+                sleep 1
+                attempts=$(( $attempts + 1 ))
+              done
+              tail -f /etc/frr/frr.log
+          env:
+            - name: TINI_SUBREAPER
+              value: "true"
+          image: quay.io/frrouting/frr:8.4.2
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 7473
+            periodSeconds: 5
+          name: frr
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+                - SYS_ADMIN
+                - NET_BIND_SERVICE
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /livez
+              port: 7473
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /var/run/frr
+              name: frr-sockets
+            - mountPath: /etc/frr
+              name: frr-conf
+        - command:
+            - /etc/frr_reloader/frr-reloader.sh
+          image: quay.io/frrouting/frr:8.4.2
+          name: reloader
+          volumeMounts:
+            - mountPath: /var/run/frr
+              name: frr-sockets
+            - mountPath: /etc/frr
+              name: frr-conf
+            - mountPath: /etc/frr_reloader
+              name: reloader
+        - args:
+            - --metrics-port=7473
+          command:
+            - /etc/frr_metrics/frr-metrics
+          image: quay.io/frrouting/frr:8.4.2
+          name: frr-metrics
+          ports:
+            - containerPort: 7473
+              name: monitoring
+          volumeMounts:
+            - mountPath: /var/run/frr
+              name: frr-sockets
+            - mountPath: /etc/frr
+              name: frr-conf
+            - mountPath: /etc/frr_metrics
+              name: metrics
         - args:
             - --port=7472
             - --log-level=info
           env:
+            - name: FRR_CONFIG_FILE
+              value: /etc/frr_reloader/frr.conf
+            - name: FRR_RELOADER_PID_FILE
+              value: /etc/frr_reloader/reloader.pid
+            - name: METALLB_BGP_TYPE
+              value: frr
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -425,7 +498,7 @@ spec:
                 secretKeyRef:
                   key: secretkey
                   name: memberlist
-          image: quay.io/metallb/speaker:v0.13.3
+          image: quay.io/metallb/speaker:v0.13.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -461,10 +534,47 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/frr_reloader
+              name: reloader
       hostNetwork: true
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - cp -rLf /tmp/frr/* /etc/frr/
+          image: quay.io/frrouting/frr:8.4.2
+          name: cp-frr-files
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 100
+          volumeMounts:
+            - mountPath: /tmp/frr
+              name: frr-startup
+            - mountPath: /etc/frr
+              name: frr-conf
+        - command:
+            - /bin/sh
+            - -c
+            - cp -f /frr-reloader.sh /etc/frr_reloader/
+          image: quay.io/metallb/speaker:main
+          name: cp-reloader
+          volumeMounts:
+            - mountPath: /etc/frr_reloader
+              name: reloader
+        - command:
+            - /bin/sh
+            - -c
+            - cp -f /frr-metrics /etc/frr_metrics/
+          image: quay.io/metallb/speaker:main
+          name: cp-metrics
+          volumeMounts:
+            - mountPath: /etc/frr_metrics
+              name: metrics
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: speaker
+      shareProcessNamespace: true
       terminationGracePeriodSeconds: 2
       tolerations:
         - effect: NoSchedule
@@ -473,6 +583,18 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Exists
+      volumes:
+        - emptyDir: {}
+          name: frr-sockets
+        - configMap:
+            name: frr-startup
+          name: frr-startup
+        - emptyDir: {}
+          name: frr-conf
+        - emptyDir: {}
+          name: reloader
+        - emptyDir: {}
+          name: metrics
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -502,11 +624,13 @@ spec:
             - --port=7472
             - --log-level=info
           env:
+            - name: METALLB_BGP_TYPE
+              value: frr
             - name: METALLB_ML_SECRET_NAME
               value: memberlist
             - name: METALLB_DEPLOYMENT
               value: controller
-          image: quay.io/metallb/controller:v0.13.3
+          image: quay.io/metallb/controller:v0.13.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -701,3 +825,101 @@ webhooks:
         resources:
           - l2advertisements
     sideEffects: None
+---
+apiVersion: v1
+data:
+  daemons: |
+    # This file tells the frr package which daemons to start.
+    #
+    # Sample configurations for these daemons can be found in
+    # /usr/share/doc/frr/examples/.
+    #
+    # ATTENTION:
+    #
+    # When activating a daemon for the first time, a config file, even if it is
+    # empty, has to be present *and* be owned by the user and group "frr", else
+    # the daemon will not be started by /etc/init.d/frr. The permissions should
+    # be u=rw,g=r,o=.
+    # When using "vtysh" such a config file is also needed. It should be owned by
+    # group "frrvty" and set to ug=rw,o= though. Check /etc/pam.d/frr, too.
+    #
+    # The watchfrr and zebra daemons are always started.
+    #
+    bgpd=yes
+    ospfd=no
+    ospf6d=no
+    ripd=no
+    ripngd=no
+    isisd=no
+    pimd=no
+    ldpd=no
+    nhrpd=no
+    eigrpd=no
+    babeld=no
+    sharpd=no
+    pbrd=no
+    bfdd=yes
+    fabricd=no
+    vrrpd=no
+
+    #
+    # If this option is set the /etc/init.d/frr script automatically loads
+    # the config via "vtysh -b" when the servers are started.
+    # Check /etc/pam.d/frr if you intend to use "vtysh"!
+    #
+    vtysh_enable=yes
+    zebra_options="  -A 127.0.0.1 -s 90000000"
+    bgpd_options="   -A 127.0.0.1 -p 0"
+    ospfd_options="  -A 127.0.0.1"
+    ospf6d_options=" -A ::1"
+    ripd_options="   -A 127.0.0.1"
+    ripngd_options=" -A ::1"
+    isisd_options="  -A 127.0.0.1"
+    pimd_options="   -A 127.0.0.1"
+    ldpd_options="   -A 127.0.0.1"
+    nhrpd_options="  -A 127.0.0.1"
+    eigrpd_options=" -A 127.0.0.1"
+    babeld_options=" -A 127.0.0.1"
+    sharpd_options=" -A 127.0.0.1"
+    pbrd_options="   -A 127.0.0.1"
+    staticd_options="-A 127.0.0.1"
+    bfdd_options="   -A 127.0.0.1"
+    fabricd_options="-A 127.0.0.1"
+    vrrpd_options="  -A 127.0.0.1"
+
+    # configuration profile
+    #
+    #frr_profile="traditional"
+    #frr_profile="datacenter"
+
+    #
+    # This is the maximum number of FD's that will be available.
+    # Upon startup this is read by the control files and ulimit
+    # is called. Uncomment and use a reasonable value for your
+    # setup if you are expecting a large number of peers in
+    # say BGP.
+    #MAX_FDS=1024
+
+    # The list of daemons to watch is automatically generated by the init script.
+    #watchfrr_options=""
+
+    # for debugging purposes, you can specify a "wrap" command to start instead
+    # of starting the daemon directly, e.g. to use valgrind on ospfd:
+    #   ospfd_wrap="/usr/bin/valgrind"
+    # or you can use "all_wrap" for all daemons, e.g. to use perf record:
+    #   all_wrap="/usr/bin/perf record --call-graph -"
+    # the normal daemon command is added to this at the end.
+  frr.conf: |
+    ! This file gets overridden the first time the speaker renders a config.
+    ! So anything configured here is only temporary.
+    frr version 7.5.1
+    frr defaults traditional
+    hostname Router
+    line vty
+    log file /etc/frr/frr.log informational
+  vtysh.conf: |
+    service integrated-vtysh-config
+kind: ConfigMap
+metadata:
+  name: frr-startup
+  namespace: metallb-system

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -18,6 +18,7 @@ from validators import (
     validate_metrics_server,
     validate_rbac,
     validate_metallb_config,
+    validate_metallb_frr_mode,
     validate_observability,
     validate_coredns_config,
     validate_mayastor,
@@ -274,8 +275,28 @@ class TestAddons(object):
             "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
         )
         print("Enabling metallb")
-        microk8s_enable("{}:{}".format(addon, ip_ranges), timeout_insec=500)
+        output = microk8s_enable(
+            "{}:{}:{}:{}".format(addon, ip_ranges, "no-frr", "ignore"),
+            timeout_insec=500,
+        )
         validate_metallb_config(ip_ranges)
+        print("Disabling metallb")
+        microk8s_disable("metallb")
+
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="Metallb tests are only relevant in x86 architectures",
+    )
+    def test_metallb_frr_addon(self):
+        addon = "metallb"
+        ip_ranges = (
+            "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
+        )
+        print("Enabling metallb in frr mode")
+        output = microk8s_enable(
+            "{}:{}:{}:{}".format(addon, ip_ranges, "frr", "ignore"), timeout_insec=500
+        )
+        validate_metallb_frr_mode()
         print("Disabling metallb")
         microk8s_disable("metallb")
 

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -371,6 +371,32 @@ def validate_metallb_config(ip_ranges="192.168.0.105"):
         assert ip_range in out
 
 
+def validate_metallb_frr_mode():
+    """
+    Validate that MetalLB has been installed with frr mode enabled
+    """
+    if platform.machine() != "x86_64":
+        print("Metallb tests are only relevant in x86 architectures")
+        return
+    pods = (
+        kubectl("get pod -n metallb-system -o=jsonpath='{.items..metadata.name}'")
+        .replace("'", "")
+        .replace('"', "")
+    )
+    frr_component_count = 0
+    for pod in pods.split(" "):
+        if "speaker" in pod:
+            containers_in_pod = kubectl(
+                "get pods "
+                + "{}".format(pod)
+                + " -o jsonpath='{.spec.containers[*].name}' -n metallb-system"
+            )
+            for container in containers_in_pod.split(" "):
+                if "frr" in str(container):
+                    frr_component_count += 1
+    assert frr_component_count > 0
+
+
 def validate_coredns_config(nameservers="8.8.8.8,1.1.1.1"):
     """
     Validate dns


### PR DESCRIPTION
This PR adds the possibility to enable the MetalLB plugin in FRR mode. This is required for IPv6 Peering sessions. 
While writing tests for this mode, i came across an issue with the `validatingwebhookconfiguration`, which is described here:
https://github.com/metallb/metallb/issues/1597

As the maintainers of MetalLB say themselves, this issue is entirely unpredictable and occurs seemingly at random. This is kind of bad, especially for automated tests. Hence, I added a turn-off flag for the validation webhooks. This can be dangerous, as the manifests wont get sanity checked by metallb then, so i only added the possibility to turn this off via the flags and not via the prompt. This way, we can disable them during tests, while keeping the user from just disabling them without knowing what that actually means.

You can also take a look at this blogpost: https://blog.mowoe.com/building-a-multi-node-ipv6-enabled-bare-metal-kubernetes-cluster-with-microk8s-metallb-longhorn-and-vyos.html 
to learn more about why frr-mode is handy.