### PR TITLE
Assume test in the user path

### DIFF
--- a/addons/cis-hardening/cfg/cis-1.24-microk8s/etcd.yaml
+++ b/addons/cis-hardening/cfg/cis-1.24-microk8s/etcd.yaml
@@ -62,12 +62,12 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "if /bin/test -e /var/snap/microk8s/current/var/kubernetes/backend/cluster.crt && /bin/test -e /var/snap/microk8s/current/var/kubernetes/backend/cluster.key; then echo 'certs-found'; fi"
+        audit: "if test -e /var/snap/microk8s/current/var/kubernetes/backend/cluster.crt && test -e /var/snap/microk8s/current/var/kubernetes/backend/cluster.key; then echo 'certs-found'; fi"
         tests:
           test_items:
             - flag: "certs-found"
         remediation: |
-          MicroK8s used dqlite and tls peer communication uses the certificate pair
+          The certificate pair for dqlite and tls peer communication is
           /var/snap/microk8s/current/var/kubernetes/backend/cluster.crt and
           /var/snap/microk8s/current/var/kubernetes/backend/cluster.key.
         scored: true


### PR DESCRIPTION
The `test` may not be under `/bin/`. This PR fixes the test failure in our CI and improves the wording in the 2.4 test.
