### PR TITLE
Fix RBAC rules of metrics server

### DIFF
--- a/addons/metrics-server/metrics-server.yaml
+++ b/addons/metrics-server/metrics-server.yaml
@@ -36,12 +36,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
       - pods
       - nodes
-      - nodes/metrics
-      - nodes/stats
-      - namespaces
-      - configmaps
     verbs:
       - get
       - list

--- a/addons/metrics-server/metrics-server.yaml
+++ b/addons/metrics-server/metrics-server.yaml
@@ -38,6 +38,7 @@ rules:
     resources:
       - pods
       - nodes
+      - nodes/metrics
       - nodes/stats
       - namespaces
       - configmaps


### PR DESCRIPTION
When enabling the metrics server under RBAC we get the metrics-server pod not getting to Ready state. The error it reports is:
```
E0710 15:22:18.750492       1 scraper.go:140] "Failed to scrape node" err="request failed, status: \"403 Forbidden\"" node="ip-172-31-3-156"
I0710 15:22:25.658360       1 server.go:187] "Failed probe" probe="metric-storage-ready" err="no metrics to serve"
```

The logs of kubelite look like this:
```
Jul 10 15:23:14 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: E0710 15:23:14.966647 1426885 controller.go:113] loading OpenAPI spec for "v1beta1.metrics.k8s.io" failed with: Error, could not get list of group versions for APIService
Jul 10 15:23:14 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: E0710 15:23:14.966656 1426885 controller.go:116] loading OpenAPI spec for "v1beta1.metrics.k8s.io" failed with: failed to retrieve openAPI spec, http error: ResponseCode: 503, Body: service unavailable
Jul 10 15:23:14 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: , Header: map[Content-Type:[text/plain; charset=utf-8] X-Content-Type-Options:[nosniff]]
Jul 10 15:23:14 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: I0710 15:23:14.966658 1426885 controller.go:126] OpenAPI AggregationController: action for item v1beta1.metrics.k8s.io: Rate Limited Requeue.
Jul 10 15:23:14 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: I0710 15:23:14.967786 1426885 controller.go:129] OpenAPI AggregationController: action for item v1beta1.metrics.k8s.io: Rate Limited Requeue.
Jul 10 15:23:20 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: E0710 15:23:20.681162 1426885 resource_quota_controller.go:441] unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: stale GroupVersion discovery: metrics.k8s.io/v1beta1
Jul 10 15:23:21 ip-172-31-3-156 microk8s.daemon-kubelite[1426885]: W0710 15:23:21.024446 1426885 garbagecollector.go:816] failed to discover some groups: map[metrics.k8s.io/v1beta1:stale GroupVersion discovery: metrics.k8s.io/v1beta1]
```
This PR fixes this issue.