### PR TITLE
Do not leave a single node cluster when disable HA

### DIFF
--- a/addons/ha-cluster/disable
+++ b/addons/ha-cluster/disable
@@ -38,7 +38,6 @@ then
 fi
 
 echo "Reverting to a non-HA setup"
-"${SNAP}/microk8s-leave.wrapper"
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 &>/dev/null
 
 workers=$("$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get no | grep " Ready" | wc -l)


### PR DESCRIPTION
Because of this: https://github.com/canonical/microk8s/pull/4023 we are not to `microk8s leave` on a single node cluster.