### PR TITLE
Do not block if ceph cluster is not yet ready

### DIFF
--- a/addons/rook-ceph/plugin/connect-external-ceph
+++ b/addons/rook-ceph/plugin/connect-external-ceph
@@ -9,7 +9,6 @@ from typing import Tuple
 
 import click
 import rados
-import rbd
 
 DIR = Path(__file__).absolute().parent
 
@@ -69,23 +68,24 @@ def ceph_initialize_rbd_pool(ceph_conf: str, keyring: str, rbd_pool: str):
 
     click.echo("Attempting to connect to Ceph cluster")
     client.connect()
-    click.echo("Successfully connected to Ceph cluster")
+    click.echo(f"Successfully connected to {client.get_fsid()} ({client.get_addrs()})")
 
     try:
         if client.pool_exists(rbd_pool):
-            click.echo(f"WARNING: Pool {rbd_pool} already exists, will not do anything")
-            return
+            click.echo(f"WARNING: Pool {rbd_pool} already exists")
+        else:
+            # ceph osd pool create $rbd_pool
+            click.echo(f"Creating pool {rbd_pool} in Ceph cluster")
+            client.create_pool(rbd_pool)
 
-        # ceph osd pool create $rbd_pool
-        click.echo(f"Creating pool {rbd_pool} in Ceph cluster")
-        client.create_pool(rbd_pool)
-
-        click.echo("Initializing RBD pool")
+        click.echo(f"Configuring pool {rbd_pool} for RBD")
         with client.open_ioctx(rbd_pool) as ioctx:
-            # rbd pool init $rbd_pool
-            rbd.RBD().pool_init(ioctx, False)
+            # ceph osd pool application get $rbd_pool
+            if "rbd" not in ioctx.application_list():
+                # ceph osd pool application enable $rbd_pool rbd
+                ioctx.application_enable("rbd")
 
-        click.echo(f"Successfully initialized RBD pool {rbd_pool}")
+        click.echo(f"Successfully configured pool {rbd_pool} for RBD")
     finally:
         client.shutdown()
 


### PR DESCRIPTION
## Summary

Rework how we prepare the osd pool for RBD so that it does not hang if the ceph cluster is not in a healthy state.

## Testing

- install microk8s from latest edge
- microk8s enable rook-ceph
- snap install microceph --edge
- initialize microceph, but do not add any osds yet
- microk8s connect-external-ceph

Without this change, the command above would hang forever. It now proceeds without issues, and initialization is deferred until OSDs are available in the Ceph cluster.