### PR TITLE
Tell users to use sudo when calling the rook-ceph plugin

### DIFF
--- a/addons/rook-ceph/enable
+++ b/addons/rook-ceph/enable
@@ -73,11 +73,11 @@ To connect MicroK8s with an existing Ceph cluster, you can use the helper comman
 'microk8s connect-external-ceph'. If you are running MicroCeph on the same node, then
 you can use the following command:
 
-    microk8s connect-external-ceph
+    sudo microk8s connect-external-ceph
 
 Alternatively, you can connect MicroK8s with any external Ceph cluster using:
 
-    microk8s connect-external-ceph \\
+    sudo microk8s connect-external-ceph \\
         --ceph-conf /path/to/cluster/ceph.conf \\
         --keyring /path/to/cluster/ceph.keyring \\
         --rbd-pool microk8s-rbd


### PR DESCRIPTION
We have users reporting sudo is needed for calling `microk8s connect-external-ceph` https://discuss.kubernetes.io/t/howto-setup-microk8s-with-micro-ceph-storage/25043/2 . This is probably a permissions problem we need to address. This PR is a small mitigation.