### PR TITLE
Update mayastor to v2.0.0-microk8s-1b

### DIFF
--- a/addons/mayastor/chart/Chart.yaml
+++ b/addons/mayastor/chart/Chart.yaml
@@ -3,9 +3,9 @@ name: mayastor-aio
 description: A Helm chart to deploy zero-ops Mayastor to a Kubernetes cluster
 
 type: application
-version: 2.0.0-microk8s-1
+version: 2.0.0-microk8s-1b
 
-appVersion: "2.0.0-microk8s-1"
+appVersion: "2.0.0-microk8s-1b"
 
 dependencies:
   - name: etcd-operator
@@ -13,5 +13,5 @@ dependencies:
     repository: https://raw.githubusercontent.com/canonical/etcd-operator/master/chart
   # TODO(neoaggelos): Replace this with repository after upstream release of our changes
   - name: mayastor
-    version: 2.0.0-microk8s-1
-    repository: https://github.com/canonical/mayastor-extensions/releases/download/v2.0.0-microk8s-1
+    version: 2.0.0-microk8s-1b
+    repository: https://github.com/canonical/mayastor-extensions/releases/download/v2.0.0-microk8s-1b

--- a/addons/mayastor/chart/README.md
+++ b/addons/mayastor/chart/README.md
@@ -140,6 +140,7 @@ git clone https://github.com/canonical/mayastor-extensions -b v2.0.0-microk8s
 cd mayastor-extensions
 
 # make any adjustments to the helm chart, under the "chart/" folder
+# - to update version, edit chart/Chart.yaml
 
 # push changes, tag new release
 git push origin v2.0.0-microk8s
@@ -147,6 +148,7 @@ git tag v2.0.0-microk8s-1
 git push origin v2.0.0-microk8s-1
 
 # package helm chart and create index.yaml for repository
+( cd chart && helm dependency update )
 helm package chart
 helm repo index .
 ```


### PR DESCRIPTION
### Summary

Update mayastor to v2.0.0-microk8s-1b, see https://github.com/canonical/mayastor-extensions/releases/tag/v2.0.0-microk8s-1b

Must be backported to 1.27 after merging