### PR TITLE
Update run-tests.yml for 1.28-strict

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
           sudo microk8s addons repo remove core
           sudo microk8s addons repo add core .
           export UNDER_TIME_PRESSURE="True"
-          if [[ "${{ matrix.channel }}" == "latest/edge/strict" ]]
+          if [[ "${{ matrix.channel }}" == "1.28-strict/edge" ]]
           then
             export STRICT="yes"
           fi


### PR DESCRIPTION
We missed this on the 1.28 branch preparation