### PR TITLE
Start nvidia addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -79,10 +79,18 @@ microk8s-addons:
         - s390x
         - ppc64le
 
+    - name: "nvidia"
+      description: "NVIDIA hardware (GPU and network) support"
+      version: "gpu=22.9.1/network=23.7.0/microk8s-1"
+      check_status: "operator-node-feature-discovery"
+      confinement: "classic"
+      supported_architectures:
+        - amd64
+
     - name: "gpu"
-      description: "Automatic enablement of Nvidia CUDA"
+      description: "Alias to nvidia add-on"
       version: "22.9.1"
-      check_status: "daemonset.apps/nvidia-device-plugin-daemonset"
+      check_status: "operator-node-feature-discovery"
       confinement: "classic"
       supported_architectures:
         - amd64

--- a/addons/gpu/disable
+++ b/addons/gpu/disable
@@ -1,34 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
 
-import os
-import json
-import pathlib
-import subprocess
+DIR=`realpath $(dirname $0)`
 
-import click
+echo "
+WARNING: The gpu addon has been renamed to nvidia.
 
-SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
-HELM = SNAP / "microk8s-helm3.wrapper"
+Please use 'microk8s disable nvidia' instead.
 
+"
 
-@click.command()
-def main():
-    click.echo("Disabling NVIDIA GPU support")
-    try:
-        stdout = subprocess.check_output([HELM, "ls", "-A", "-o", "json"])
-        charts = json.loads(stdout)
-    except (OSError, json.JSONDecodeError):
-        click.echo("ERROR: Failed to retrieve installed charts", err=True)
-        charts = []
-
-    for chart in charts:
-        name = chart.get("name")
-        if chart.get("name") == "gpu-operator":
-            namespace = chart.get("namespace") or "default"
-            subprocess.run([HELM, "uninstall", name, "-n", namespace])
-
-    click.echo("GPU support disabled")
-
-
-if __name__ == "__main__":
-    main()
+$DIR/../nvidia/disable "${@}"

--- a/addons/gpu/enable
+++ b/addons/gpu/enable
@@ -1,118 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
 
-import json
-import os
-import pathlib
-import subprocess
-import time
+DIR=`realpath $(dirname $0)`
 
-import click
+echo "
+WARNING: The gpu addon has been renamed to nvidia.
 
+Please use 'microk8s enable nvidia' instead.
 
-DIR = pathlib.Path(__file__).absolute().parent
-SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
-SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA") or "/var/snap/microk8s/current")
-SNAP_CURRENT = SNAP_DATA.parent / "current"
-SNAP_COMMON = pathlib.Path(os.getenv("SNAP_COMMON") or "/var/snap/microk8s/common")
+"
 
-HELM = SNAP / "microk8s-helm3.wrapper"
-MICROK8S_ENABLE = SNAP / "microk8s-enable.wrapper"
-CONTAINERD_SOCKET = SNAP_COMMON / "run" / "containerd.sock"
-CONTAINERD_TOML = SNAP_CURRENT / "args" / "containerd-template.toml"
-
-
-def log(msg):
-    click.echo(msg, err=True)
-
-
-@click.command()
-@click.argument(
-    "driver-type",
-    default="",
-    type=click.Choice(["", "force-operator-driver", "force-system-driver"]),
-)
-@click.option("--requires", multiple=True, default=["core/dns", "core/helm3"])
-@click.option("--version", default="v22.9.1")
-@click.option("--driver", default="auto", type=click.Choice(["auto", "operator", "host"]))
-@click.option("--toolkit-version", default=None)
-@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, default=True)
-@click.option("--set", "helm_set", multiple=True)
-@click.option("-f", "--values", "helm_values", multiple=True, type=click.Path(exists=True))
-def main(
-    requires: list,
-    version: str,
-    driver_type: str,
-    driver: str,
-    toolkit_version: str,
-    set_as_default_runtime: bool,
-    helm_set: list,
-    helm_values: list,
-):
-    click.echo("Enabling NVIDIA GPU")
-
-    for addon in requires:
-        subprocess.run([MICROK8S_ENABLE, addon])
-
-    # handle the deprecated force-operator-driver and force-system-driver options
-    if driver_type == "force-operator-driver":
-        driver = "operator"
-        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=operator")
-    elif driver_type == "force-system-driver":
-        driver = "host"
-        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=host")
-    elif driver == "auto":
-        try:
-            click.echo("Checking if NVIDIA driver is already installed")
-            subprocess.check_call(["nvidia-smi", "-L"])
-            driver = "host"
-        except OSError:
-            driver = "operator"
-
-    click.echo(f"Using {driver} GPU driver")
-    helm_args = [
-        "install",
-        "gpu-operator",
-        "nvidia/gpu-operator",
-        f"--version={version}",
-        "--create-namespace",
-        "--namespace=gpu-operator-resources",
-        "-f",
-        "-",
-    ]
-
-    helm_config = {
-        "operator": {
-            "defaultRuntime": "containerd",
-        },
-        "driver": {
-            "enabled": ("true" if driver == "operator" else "false"),
-        },
-        "toolkit": {
-            "enabled": "true",
-            "env": [
-                {"name": "CONTAINERD_CONFIG", "value": CONTAINERD_TOML.as_posix()},
-                {"name": "CONTAINERD_SOCKET", "value": CONTAINERD_SOCKET.as_posix()},
-                {
-                    "name": "CONTAINERD_SET_AS_DEFAULT",
-                    "value": "1" if set_as_default_runtime else "0",
-                },
-            ],
-        },
-    }
-    if toolkit_version is not None:
-        helm_config["toolkit"]["version"] = toolkit_version
-
-    for arg in helm_set:
-        helm_args.extend(["--set", arg])
-    for arg in helm_values:
-        helm_args.extend(["--values", arg])
-
-    subprocess.run([HELM, "repo", "add", "nvidia", "https://nvidia.github.io/gpu-operator"])
-    subprocess.run([HELM, "repo", "update", "nvidia"])
-    subprocess.run([HELM, *helm_args], input=json.dumps(helm_config).encode())
-
-    click.echo("NVIDIA is enabled")
-
-
-if __name__ == "__main__":
-    main()
+$DIR/../nvidia/enable "${@}"

--- a/addons/nvidia/disable
+++ b/addons/nvidia/disable
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import pathlib
+import subprocess
+
+import click
+
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+HELM = SNAP / "microk8s-helm3.wrapper"
+
+
+@click.command()
+def main():
+    click.echo("Disabling NVIDIA support")
+    try:
+        stdout = subprocess.check_output([HELM, "ls", "-A", "-o", "json"])
+        charts = json.loads(stdout)
+    except (OSError, json.JSONDecodeError):
+        click.echo("ERROR: Failed to retrieve installed charts", err=True)
+        charts = []
+
+    for chart in charts:
+        name = chart.get("name")
+        if chart.get("name") in ["gpu-operator", "network-operator"]:
+            namespace = chart.get("namespace") or "default"
+            subprocess.run([HELM, "uninstall", name, "-n", namespace])
+
+    click.echo("NVIDIA support disabled")
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/nvidia/enable
+++ b/addons/nvidia/enable
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import click
+
+
+DIR = pathlib.Path(__file__).absolute().parent
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+SNAP_DATA = pathlib.Path(os.getenv("SNAP_DATA") or "/var/snap/microk8s/current")
+SNAP_CURRENT = SNAP_DATA.parent / "current"
+SNAP_COMMON = pathlib.Path(os.getenv("SNAP_COMMON") or "/var/snap/microk8s/common")
+
+HELM = SNAP / "microk8s-helm3.wrapper"
+MICROK8S_ENABLE = SNAP / "microk8s-enable.wrapper"
+CONTAINERD_SOCKET = SNAP_COMMON / "run" / "containerd.sock"
+CONTAINERD_TOML = SNAP_CURRENT / "args" / "containerd-template.toml"
+
+
+def deploy_network_operator(version: str, helm_set: list, helm_values: list):
+    click.echo("Deploy NVIDIA Network operator")
+    helm_args = [
+        "install",
+        "network-operator",
+        "nvidia/network-operator",
+        f"--version={version}",
+        "--create-namespace",
+        "--namespace=nvidia-network-operator",
+    ]
+
+    for arg in helm_set:
+        helm_args.extend(["--set", arg])
+    for arg in helm_values:
+        helm_args.extend(["--values", arg])
+
+    if not helm_values and not helm_set:
+        # FIXME(neoaggelos): update docs and then improve the wording here
+        click.echo("WARNING: Extra configuration might be needed for network-operator")
+        click.echo("Please refer to the docs for more details")
+
+    subprocess.run([HELM, *helm_args])
+
+    click.echo("Deployed NVIDIA Network operator")
+
+
+def deploy_gpu_operator(
+    version: str,
+    helm_set: list,
+    helm_values: list,
+    toolkit_version: str,
+    driver: str,
+    set_as_default_runtime: bool,
+):
+    click.echo("Deploy NVIDIA GPU operator")
+
+    click.echo(f"Using {driver} GPU driver")
+    helm_args = [
+        "install",
+        "gpu-operator",
+        "nvidia/gpu-operator",
+        f"--version={version}",
+        "--create-namespace",
+        "--namespace=gpu-operator-resources",
+        "-f",
+        "-",
+    ]
+
+    helm_config = {
+        "operator": {
+            "defaultRuntime": "containerd",
+        },
+        "driver": {
+            "enabled": ("true" if driver == "operator" else "false"),
+        },
+        "toolkit": {
+            "enabled": "true",
+            "env": [
+                {"name": "CONTAINERD_CONFIG", "value": CONTAINERD_TOML.as_posix()},
+                {"name": "CONTAINERD_SOCKET", "value": CONTAINERD_SOCKET.as_posix()},
+                {
+                    "name": "CONTAINERD_SET_AS_DEFAULT",
+                    "value": "1" if set_as_default_runtime else "0",
+                },
+            ],
+        },
+    }
+    if toolkit_version is not None:
+        helm_config["toolkit"]["version"] = toolkit_version
+
+    for arg in helm_set:
+        helm_args.extend(["--set", arg])
+    for arg in helm_values:
+        helm_args.extend(["--values", arg])
+
+    subprocess.run([HELM, *helm_args], input=json.dumps(helm_config).encode())
+
+    click.echo("Deployed NVIDIA GPU operator")
+
+
+@click.command()
+@click.argument(
+    "driver-type",
+    default="",
+    type=click.Choice(["", "force-operator-driver", "force-system-driver"]),
+)
+@click.option("--requires", multiple=True, default=["core/dns", "core/helm3"])
+@click.option("--version", help="Deprecated, use --gpu-operator-version instead")
+@click.option("--driver", default="auto", type=click.Choice(["auto", "operator", "host"]))
+@click.option("--toolkit-version", default=None)
+@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, default=True)
+@click.option("--set", "helm_set", multiple=True)
+@click.option("-f", "--values", "helm_values", multiple=True, type=click.Path(exists=True))
+@click.option("--gpu-operator-version", default="v22.9.1")
+@click.option("--gpu-operator-set", multiple=True)
+@click.option("--gpu-operator-values", multiple=True)
+@click.option("--gpu-operator/--no-gpu-operator", is_flag=True, default=True)
+@click.option("--network-operator/--no-network-operator", is_flag=True, default=False)
+@click.option("--network-operator-version", default="23.7.0")
+@click.option("--network-operator-set", multiple=True)
+@click.option("--network-operator-values", multiple=True, type=click.Path(exists=True))
+def main(
+    requires: list,
+    # gpu-operator args
+    gpu_operator: bool,
+    gpu_operator_version: str,
+    driver: str,
+    toolkit_version: str,
+    set_as_default_runtime: bool,
+    gpu_operator_set: list,
+    gpu_operator_values: list,
+    # network-operator args
+    network_operator: bool,
+    network_operator_version: str,
+    network_operator_set: list,
+    network_operator_values: list,
+    # deprecated args
+    driver_type: str,  # (replaced by driver)
+    version: str,  # (replaced by gpu_operator_version)
+    helm_set: list,  # (replaced by gpu_operator_set)
+    helm_values: list,  # (replaced by gpu_operator_values)
+):
+    if not gpu_operator and not network_operator:
+        click.echo("ERROR: At least one of --gpu-operator or --network-operator is required")
+        sys.exit(1)
+
+    for addon in requires:
+        subprocess.run([MICROK8S_ENABLE, addon])
+
+    # handle the deprecated force-operator-driver and force-system-driver options
+    if driver_type == "force-operator-driver":
+        driver = "operator"
+        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=operator")
+    elif driver_type == "force-system-driver":
+        driver = "host"
+        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=host")
+    elif driver == "auto":
+        try:
+            click.echo("Checking if NVIDIA driver is already installed")
+            subprocess.check_call(["nvidia-smi", "-L"])
+            driver = "host"
+        except OSError:
+            driver = "operator"
+
+    # handle deprecated arguments for gpu-operator
+    if helm_set:
+        if gpu_operator_set:
+            click.echo("ERROR: Please use --gpu-operator-set instead of --set")
+            sys.exit(1)
+        click.echo("WARNING: --set is deprecated, please use --gpu-operator-set instead")
+        gpu_operator_set = helm_set
+
+    if helm_values:
+        if gpu_operator_values:
+            click.echo("ERROR: Please use --gpu-operator-values instead of -f/--values")
+            sys.exit(1)
+        click.echo("WARNING: -f/--values is deprecated, please use --gpu-operator-values instead")
+        gpu_operator_values = helm_values
+
+    if version:
+        if gpu_operator_version:
+            click.echo("ERROR: Please use --gpu-operator-version instead of --version")
+            sys.exit(1)
+        click.echo("WARNING: --version is deprecated, please use --gpu-operator-version instead")
+        gpu_operator_version = version
+
+    # add helm repository for nvidia gpu-operator and network-operator
+    subprocess.run([HELM, "repo", "add", "nvidia", "https://helm.ngc.nvidia.com/nvidia"])
+    subprocess.run([HELM, "repo", "update", "nvidia"])
+
+    if gpu_operator:
+        deploy_gpu_operator(
+            gpu_operator_version,
+            gpu_operator_set,
+            gpu_operator_values,
+            toolkit_version,
+            driver,
+            set_as_default_runtime,
+        )
+
+    if network_operator:
+        deploy_network_operator(
+            network_operator_version,
+            network_operator_set,
+            network_operator_values,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/nvidia/enable
+++ b/addons/nvidia/enable
@@ -108,16 +108,19 @@ def deploy_gpu_operator(
     type=click.Choice(["", "force-operator-driver", "force-system-driver"]),
 )
 @click.option("--requires", multiple=True, default=["core/dns", "core/helm3"])
-@click.option("--version", help="Deprecated, use --gpu-operator-version instead")
-@click.option("--driver", default="auto", type=click.Choice(["auto", "operator", "host"]))
-@click.option("--toolkit-version", default=None)
-@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, default=True)
-@click.option("--set", "helm_set", multiple=True)
-@click.option("-f", "--values", "helm_values", multiple=True, type=click.Path(exists=True))
-@click.option("--gpu-operator-version", default="v22.9.1")
+@click.option("--version", hidden=True)
+@click.option("--gpu-operator-version")
+@click.option("--driver", type=click.Choice(["auto", "operator", "host"]), hidden=True)
+@click.option("--gpu-operator-driver", type=click.Choice(["auto", "operator", "host"]))
+@click.option("--set", "helm_set", multiple=True, hidden=True)
 @click.option("--gpu-operator-set", multiple=True)
+@click.option("-f", "--values", "helm_values", multiple=True, type=click.Path(exists=True), hidden=True)
 @click.option("--gpu-operator-values", multiple=True)
 @click.option("--gpu-operator/--no-gpu-operator", is_flag=True, default=True)
+@click.option("--toolkit-version", default=None, hidden=True)
+@click.option("--gpu-operator-toolkit-version", default=None)
+@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, hidden=True)
+@click.option("--gpu-operator-set-as-default-runtime/--gpu-operator-no-set-as-default-runtime", is_flag=True, default=True)
 @click.option("--network-operator/--no-network-operator", is_flag=True, default=False)
 @click.option("--network-operator-version", default="23.7.0")
 @click.option("--network-operator-set", multiple=True)
@@ -127,9 +130,9 @@ def main(
     # gpu-operator args
     gpu_operator: bool,
     gpu_operator_version: str,
-    driver: str,
-    toolkit_version: str,
-    set_as_default_runtime: bool,
+    gpu_operator_driver: str,
+    gpu_operator_toolkit_version: str,
+    gpu_operator_set_as_default_runtime: bool,
     gpu_operator_set: list,
     gpu_operator_values: list,
     # network-operator args
@@ -138,8 +141,11 @@ def main(
     network_operator_set: list,
     network_operator_values: list,
     # deprecated args
-    driver_type: str,  # (replaced by driver)
+    driver_type: str,  # (replaced by gpu_operator_driver)
+    driver: str,  # (replaced by gpu_operator_driver)
     version: str,  # (replaced by gpu_operator_version)
+    toolkit_version: str, # (replaced by gpu_operator_toolkit_version)
+    set_as_default_runtime: bool, # (replaced by gpu_operator_set_as_default_runtime)
     helm_set: list,  # (replaced by gpu_operator_set)
     helm_values: list,  # (replaced by gpu_operator_values)
 ):
@@ -151,19 +157,26 @@ def main(
         subprocess.run([MICROK8S_ENABLE, addon])
 
     # handle the deprecated force-operator-driver and force-system-driver options
+    if driver:
+        if gpu_operator_driver:
+            click.echo("ERROR: Please use --gpu-operator-driver instead of --driver")
+            sys.exit(1)
+        click.echo("WARNING: --driver is deprecated, please use --gpu-operator-driver instead")
+        gpu_operator_driver = driver
+
     if driver_type == "force-operator-driver":
-        driver = "operator"
-        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=operator")
+        gpu_operator_driver = "operator"
+        click.echo(f"WARNING: {driver_type} is deprecated. Please use --gpu-operator-driver=operator")
     elif driver_type == "force-system-driver":
-        driver = "host"
-        click.echo(f"WARNING: {driver_type} is deprecated. Please use --driver=host")
-    elif driver == "auto":
+        gpu_operator_driver = "host"
+        click.echo(f"WARNING: {driver_type} is deprecated. Please use --gpu-operator-driver=host")
+    elif gpu_operator_driver == "auto":
         try:
             click.echo("Checking if NVIDIA driver is already installed")
             subprocess.check_call(["nvidia-smi", "-L"])
-            driver = "host"
+            gpu_operator_driver = "host"
         except OSError:
-            driver = "operator"
+            gpu_operator_driver = "operator"
 
     # handle deprecated arguments for gpu-operator
     if helm_set:
@@ -187,6 +200,24 @@ def main(
         click.echo("WARNING: --version is deprecated, please use --gpu-operator-version instead")
         gpu_operator_version = version
 
+    if toolkit_version:
+        if gpu_operator_toolkit_version:
+            click.echo("ERROR: Please use --gpu-operator-toolkit-version instead of --toolkit-version")
+            sys.exit(1)
+        click.echo("WARNING: --toolkit-version is deprecated, please use --gpu-operator-toolkit-version instead")
+        gpu_operator_toolkit_version = toolkit_version
+
+    if not set_as_default_runtime and gpu_operator_set_as_default_runtime:
+        click.echo("WARNING: --set-as-default-runtime is deprecated, please use --gpu-operator-toolkit-version instead")
+        gpu_operator_set_as_default_runtime = set_as_default_runtime
+
+    # set default values
+    if not gpu_operator_version:
+        gpu_operator_version = "v22.9.1"
+
+    if not gpu_operator_driver:
+        gpu_operator_driver = "auto"
+
     # add helm repository for nvidia gpu-operator and network-operator
     subprocess.run([HELM, "repo", "add", "nvidia", "https://helm.ngc.nvidia.com/nvidia"])
     subprocess.run([HELM, "repo", "update", "nvidia"])
@@ -196,9 +227,9 @@ def main(
             gpu_operator_version,
             gpu_operator_set,
             gpu_operator_values,
-            toolkit_version,
-            driver,
-            set_as_default_runtime,
+            gpu_operator_toolkit_version,
+            gpu_operator_driver,
+            gpu_operator_set_as_default_runtime,
         )
 
     if network_operator:


### PR DESCRIPTION
### Summary

Rename the `gpu` addon to `nvidia`. Add support for network-operator

### Changes

- Add flag `--gpu-operator-version` and deprecate `--version`
- Add flag `--gpu-operator-set` and deprecate `--set`
- Add flag `--gpu-operator-values` and deprecate `-f/--values`
- Add flag `--gpu-operator` (default true) to deploy the gpu operator
- Add flag `--network-operator` (default false) to deploy the network operator
- Add flag `--network-operator-version` to choose the network operator version to deploy
- Add flag `--network-operator-set` and `--network-operator-values` to configure the operator
- Rename the gpu addon to nvidia, update the status check
- Keep gpu as an alias for the nvidia addon


### Examples

1. Backwards compatible deploy and configuration of GPU addon

```
sudo microk8s enable gpu --version 22.9.1
```

2. Deploy network-operator with gpu operator

```
echo '...' > network-values.yaml
sudo microk8s enable nvidia --no-gpu-operator --network-operator --network-operator-values network-values.yaml
```

3. Deploy both operators

```
sudo microk8s enable nvidia --gpu-operator --network-operator --gpu-operator-values gpu-values.yaml --network-operator-values network-values.yaml
```