### PR TITLE
Disable rook-ceph integration testing in strict

### DIFF
--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -361,6 +361,10 @@ class TestAddons(object):
         print("Disabling Rook Ceph")
         microk8s_disable("rook-ceph")
 
+    @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping rook-ceph testing in strict",
+    )
     def test_rook_ceph_integration(self):
         """
         Test Rook Ceph integration.


### PR DESCRIPTION
The test is failing with:
```
  Warning  FailedScheduling        77s               default-scheduler        0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
  Warning  FailedScheduling        70s               default-scheduler        0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
  Normal   Scheduled               68s               default-scheduler        Successfully assigned default/nginx-fs-1 to ip-172-31-13-59
  Normal   SuccessfulAttachVolume  68s               attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b"
  Warning  FailedMount             3s (x6 over 66s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b" : rpc error: code = Internal desc = an error (exit status 1) occurred while running modprobe args: [ceph]
```
Manually loading the ceph module results in:
```  
  Warning  FailedScheduling        4m48s                  default-scheduler        0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
  Warning  FailedScheduling        4m41s                  default-scheduler        0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
  Normal   Scheduled               4m39s                  default-scheduler        Successfully assigned default/nginx-fs-1 to ip-172-31-13-59
  Normal   SuccessfulAttachVolume  4m39s                  attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b"
  Warning  FailedMount             2m30s (x7 over 4m37s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b" : rpc error: code = Internal desc = an error (exit status 1) occurred while running modprobe args: [ceph]
  Warning  FailedMount             27s                    kubelet                  MountVolume.SetUp failed for volume "pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b" : rpc error: code = Internal desc = failed to bind-mount /var/snap/microk8s/common/var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.cephfs.csi.ceph.com/7e92a41d8c529d958d2864647e89f35ce78324f5a8840496bd308a61f631a597/globalmount to /var/snap/microk8s/common/var/lib/kubelet/pods/dceb31d8-5d84-4891-bdca-387f4aaf62e4/volumes/kubernetes.io~csi/pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b/mount: an error (exit status 16) occurred while running mount args: [-o bind,_netdev /var/snap/microk8s/common/var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.cephfs.csi.ceph.com/7e92a41d8c529d958d2864647e89f35ce78324f5a8840496bd308a61f631a597/globalmount /var/snap/microk8s/common/var/lib/kubelet/pods/dceb31d8-5d84-4891-bdca-387f4aaf62e4/volumes/kubernetes.io~csi/pvc-e0be2484-53c8-42dc-a63d-2a332162ab7b/mount]
```

Needs some further investigation.