### PR TITLE
Ingress: Add the ability to specify the publish status address

### DIFF
--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -25,7 +25,7 @@ echo "Enabling Ingress"
 
 ARCH=$(arch)
 TAG="v1.8.0"
-EXTRA_ARGS="- --publish-status-address=127.0.0.1"
+EXTRA_ARGS="- --publish-status-address=${PUBLISH_STATUS_ADDRESS:-127.0.0.1}"
 DEFAULT_CERT="- ' '"
 
 if [ ! -z "$CERT_SECRET" ]


### PR DESCRIPTION
Ingress: Add the ability to specify the `--publish-status-address` via a environment variable when enabling the addon 

Fixes #256 

Usage example:
```bash
PUBLISH_STATUS_ADDRESS=$(curl -4 ifconfig.io) microk8s enable ingress
```