### PR TITLE
Fix the --set-as-default-runtime deprecation warning

### DIFF
--- a/addons/nvidia/enable
+++ b/addons/nvidia/enable
@@ -119,7 +119,7 @@ def deploy_gpu_operator(
 @click.option("--gpu-operator/--no-gpu-operator", is_flag=True, default=True)
 @click.option("--toolkit-version", default=None, hidden=True)
 @click.option("--gpu-operator-toolkit-version", default=None)
-@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, hidden=True)
+@click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, hidden=True, default=None)
 @click.option("--gpu-operator-set-as-default-runtime/--gpu-operator-no-set-as-default-runtime", is_flag=True, default=True)
 @click.option("--network-operator/--no-network-operator", is_flag=True, default=False)
 @click.option("--network-operator-version", default="23.7.0")
@@ -207,8 +207,8 @@ def main(
         click.echo("WARNING: --toolkit-version is deprecated, please use --gpu-operator-toolkit-version instead")
         gpu_operator_toolkit_version = toolkit_version
 
-    if not set_as_default_runtime and gpu_operator_set_as_default_runtime:
-        click.echo("WARNING: --set-as-default-runtime is deprecated, please use --gpu-operator-toolkit-version instead")
+    if set_as_default_runtime is not None:
+        click.echo("WARNING: --set-as-default-runtime is deprecated, please use --gpu-operator-set-as-default-runtime instead")
         gpu_operator_set_as_default_runtime = set_as_default_runtime
 
     # set default values


### PR DESCRIPTION
Fixes #269.

I believe the previously intended behavior was to check if the two flags are different, but the default value of `--set-as-default-runtime` was `None`, so the if statement on line 210 evaluated to True by default. Changed it the warning is written whenever the old flag is set to any value, regardless of the new flag.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
