### PR TITLE
Allow IPV6 ranges for Metallb addon

### DIFF
--- a/addons/metallb/enable
+++ b/addons/metallb/enable
@@ -22,9 +22,9 @@ then
   if [ -z "${ip_range_input}" ]
   then
     echo "You have to input an IP Range value when asked, or provide it as an argument to the enable command, eg:"
-    echo "  microk8s enable metallb:10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111"
+    echo "  microk8s enable metallb 10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111"
     echo "You can also use CIDR notation, eg."
-    echo "  microk8s enable metallb:192.168.1.240/24"
+    echo "  microk8s enable metallb 192.168.1.240/24"
     exit 1
   fi
 else

--- a/addons/metallb/enable
+++ b/addons/metallb/enable
@@ -30,13 +30,15 @@ then
 else
   ip_range_input="${ARGUMENTS[@]}"
 fi
-REGEX_IP_RANGE='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'
-REGEX_IP_CIDR='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9]{1,3}\/[0-9]{1,3}$'
+REGEX_IPV4_RANGE='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'
+REGEX_IPV4_CIDR='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9]{1,3}\/[0-9]{1,3}$'
+REGEX_IPV6_RANGE='^(([0-9a-fA-F]{1,4}:){1,7}((([0-9a-fA-F]{1,4})?(:[0-9a-fA-F]{1,4}){1,6})|:))-(([0-9a-fA-F]{1,4}:){1,7}((([0-9a-fA-F]{1,4})?(:[0-9a-fA-F]{1,4}){1,6})|:))$'
+REGEX_IPV6_CIDR='^(([0-9a-fA-F]{1,4}:){1,7}((([0-9a-fA-F]{1,4})?(:[0-9a-fA-F]{1,4}){1,6})|:))\/[0-9]{1,3}$'
 ip_ranges=(`echo $ip_range_input | sed 's/,/\n/g'`)
 ip_range_str="addresses:"
 for ip_range in "${ip_ranges[@]}"
 do
-  if [[ $ip_range =~ $REGEX_IP_RANGE ||  $ip_range =~ $REGEX_IP_CIDR ]]
+  if [[ $ip_range =~ $REGEX_IPV4_RANGE ||  $ip_range =~ $REGEX_IPV4_CIDR || $ip_range =~ $REGEX_IPV6_RANGE ||  $ip_range =~ $REGEX_IPV6_CIDR ]]
   then
     ip_range_str="${ip_range_str}\n      - ${ip_range}"
   else

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -276,7 +276,7 @@ class TestAddons(object):
             "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28,fd00:db8:1::/64,fd01:db9::-fd01:db9::1:FFFF"
         )
         print("Enabling metallb")
-        microk8s_enable("{}:{}".format(addon, ip_ranges), timeout_insec=500)
+        microk8s_enable("{} {}".format(addon, ip_ranges), timeout_insec=500)
         validate_metallb_config(ip_ranges)
         print("Disabling metallb")
         microk8s_disable("metallb")

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -272,9 +272,7 @@ class TestAddons(object):
     )
     def test_metallb_addon(self):
         addon = "metallb"
-        ip_ranges = (
-            "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28,fd00:db8:1::/64,fd01:db9::-fd01:db9::1:FFFF"
-        )
+        ip_ranges = "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28,fd00:db8:1::/64,fd01:db9::-fd01:db9::1:FFFF"
         print("Enabling metallb")
         microk8s_enable("{} {}".format(addon, ip_ranges), timeout_insec=500)
         validate_metallb_config(ip_ranges)

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -273,7 +273,7 @@ class TestAddons(object):
     def test_metallb_addon(self):
         addon = "metallb"
         ip_ranges = (
-            "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
+            "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28,fd00:db8:1::/64,fd01:db9::-fd01:db9::1:FFFF"
         )
         print("Enabling metallb")
         microk8s_enable("{}:{}".format(addon, ip_ranges), timeout_insec=500)


### PR DESCRIPTION
This PR allows to use IPv6 ranges or CIDR when enabling metallb addons.

Closes #245

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

The CLA is requiring informations I do not have... so I cannot sign it.
