### PR TITLE
MetalLB: Delete cluster roles and bindings on disable

### DIFF
--- a/addons/metallb/disable
+++ b/addons/metallb/disable
@@ -20,4 +20,9 @@ $KUBECTL delete -f $CURRENT_DIR/crd.yaml
 
 $KUBECTL delete namespaces metallb-system
 
+$KUBECTL delete clusterrolebinding/metallb-system:controller
+$KUBECTL delete clusterrolebinding/metallb-system:speaker
+$KUBECTL delete clusterrole/metallb-system:controller
+$KUBECTL delete clusterrole/metallb-system:speaker
+
 echo "MetalLB is terminated"


### PR DESCRIPTION
When enabling MetalLB, cluster roles and bindings are created. They are not removed when disabling MetalLB. This results in being unable to re-enable MetalLB.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
