### PR TITLE
Updates minio root user and password

### DIFF
--- a/addons/minio/enable
+++ b/addons/minio/enable
@@ -99,6 +99,7 @@ if [ "x${CREATE_TENANT}" = "xyes" ]; then
   fi
 
   set -x
+  # secrets and tenant.configSecret are mutually exclusive.
   $HELM upgrade --install "${TENANT}" tenant \
     --repo $REPO --version "${VERSION}" \
     --namespace "minio-operator" \
@@ -108,6 +109,11 @@ if [ "x${CREATE_TENANT}" = "xyes" ]; then
     --set "tenant.pools[0].size=${CAPACITY}" \
     --set "tenant.pools[0].servers=${SERVERS}" \
     --set "tenant.pools[0].volumesPerServer=${VOLUMES}" \
+    --set "tenant.configuration.name=${TENANT}-env-configuration" \
+    --set "tenant.configSecret.name=${TENANT}-env-configuration" \
+    --set "tenant.configSecret.accessKey=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20)" \
+    --set "tenant.configSecret.secretKey=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 40)" \
+    --set "secrets=" \
     ${HELM_OPTS}
   set +x
 fi


### PR DESCRIPTION
Previously, when the minio krew plugin was used to deploy the minio tenant, the root user credentials were randomly generated.

The Helm chart we're using have default values: minio, minio123.

We're now generating random strings for the root user and password. Additionally, we're updating the minio env configuration secret name to reflect the tenant name, as it was previously.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
