### PR TITLE
[Backport 1.29] minio: Adds additional minio tenant user

### DIFF
--- a/addons/minio/disable
+++ b/addons/minio/disable
@@ -3,7 +3,13 @@
 echo "Cleaning up MinIO tenants and operator"
 
 HELM="$SNAP/microk8s-helm3.wrapper"
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 NAMESPACE="minio-operator"
+
+# Delete the secret we created for the tenant.
+tenant_name="$($HELM list -n $NAMESPACE --short | grep -v 'minio-operator')"
+$KUBECTL delete -n $NAMESPACE secret "${tenant_name}-user-1"
+
 $HELM list -n $NAMESPACE --short | xargs $HELM uninstall -n $NAMESPACE
 
 echo "Disabled minio addon."

--- a/addons/minio/enable
+++ b/addons/minio/enable
@@ -88,6 +88,15 @@ if [ "x${CREATE_TENANT}" = "xyes" ]; then
   echo "  Prometheus: ${PROMETHEUS}"
   echo ""
 
+  # Previously, kubectl-minio created an additional user. We will create here as well.
+  # This is done by creating a secret containing CONSOLE_ACCESS_KEY and CONSOLE_SECRET_KEY
+  # and referencing it in the helm chart below.
+  KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+  SECRET_NAME="${TENANT}-user-1"
+  $KUBECTL create -n minio-operator secret generic "${SECRET_NAME}" \
+    --from-literal=CONSOLE_ACCESS_KEY="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20)" \
+    --from-literal=CONSOLE_SECRET_KEY="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 40)"
+
   HELM_OPTS=
 
   if [ "x${TLS}" = "xno" ]; then
@@ -103,6 +112,7 @@ if [ "x${CREATE_TENANT}" = "xyes" ]; then
     --repo $REPO --version "${VERSION}" \
     --namespace "minio-operator" \
     --set "tenant.name=${TENANT}" \
+    --set "tenant.users[0].name=${SECRET_NAME}" \
     --set "tenant.pools[0].name=${TENANT}" \
     --set "tenant.pools[0].storageClassName=${STORAGE_CLASS}" \
     --set "tenant.pools[0].size=${CAPACITY}" \
@@ -116,9 +126,5 @@ fi
 echo "================================"
 echo "Enabled minio addon."
 echo ""
-echo "You can manage minio tenants using the kubectl-minio plugin."
-echo ""
-echo "For more details, use"
-echo ""
-echo "    microk8s kubectl-minio --help"
+echo "You can interact with minio through the minio client (https://min.io/docs/minio/linux/reference/minio-mc.html#minio-client)."
 echo ""


### PR DESCRIPTION
Previously, when the minio krew plugin was used to deploy the minio tenant, the krew plugin created an additional user, with the credentials set in the ``$TENANT_NAME-user-1`` Kubernetes secret.

The Helm chart we're using does not do that by default, but it does accept a list of Kubernetes secrets with ``CONSOLE_ACCESS_KEY`` (user) and ``CONSOLE_SECRET_KEY`` (password) fields set in them.

With this change, we're now creating the secret ourselves, and passing it onto the Helm chart. The minio tenant will have this new user, in addition to the regular root user. With this, the behaviour that the krew plugin had is preserved.

Additionally, removes reference to the ``kubectl-minio`` plugin since it doesn't exist anymore.

(cherry picked from commit 8340271ef8930ccc8986779b6aa8eb1096c1cd74)

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
