### PR TITLE
Fixes CI failures

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install python3-setuptools
-          sudo pip3 install black codespell==2.2.4
+          sudo pip3 install black==25.1.0 codespell==2.2.4
           sudo snap install node --classic
           sudo npm install --save-dev --save-exact -g prettier
       - name: Check Python formatting

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
+          sudo apt-get install python3-setuptools pip
           sudo pip3 install -U pytest
       - name: Running addons tests
         run: |

--- a/addons/rook-ceph/plugin/.rook-create-external-cluster-resources.py
+++ b/addons/rook-ceph/plugin/.rook-create-external-cluster-resources.py
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
black has a new version, and because of this, one of the files needs to be reformatted.

Install pip through apt-get instead.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
