### PR TITLE
tests: Fixes validate_cis_hardening assertions

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -458,14 +458,14 @@ def validate_cis_hardening():
     output = run_until_success("microk8s kube-bench")
 
     print(output)
-    assert "41 checks WARN" in output
+    assert "43 checks WARN" in output
     if os.environ.get("STRICT") == "yes":
         assert "82 checks PASS" in output
         assert "1 checks FAIL" in output
     else:
         # The extra test that is failing on strict is the permissions of the
         # systemd kubelite service definition
-        assert "83 checks PASS" in output
+        assert "81 checks PASS" in output
         assert "0 checks FAIL" in output
 
 


### PR DESCRIPTION
The tests are currently failing, expecting there to be 41 Warnings. There are now 43 Warnings. The new ones are:

```
[WARN] 2.3 Ensure that the --auto-tls argument is not set to true (Automated)
[WARN] 2.6 Ensure that the --peer-auto-tls argument is not set to true (Automated)
```

According to the documentation [1][2], these warnings are not applicable. Thus, we can safely ignore those warnings.

[1] https://github.com/canonical/microk8s-core-addons/blob/3af1d491aa6adf8f5db8299c4189d6d84e1ada09/addons/cis-hardening/README.md?plain=1#L2067
[2] https://github.com/canonical/microk8s-core-addons/blob/3af1d491aa6adf8f5db8299c4189d6d84e1ada09/addons/cis-hardening/README.md?plain=1#L2146

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
