### PR TITLE
CI: use pyenv with pinned pytest 8.3.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,9 +20,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install python3-setuptools pip
-          sudo pip3 install -U pytest
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install -r tests/requirements.txt
       - name: Running addons tests
         run: |
           set -x
@@ -36,5 +37,5 @@ jobs:
             export STRICT="yes"
           fi
           export SKIP_PROMETHEUS="False"
-          sudo -E pytest -s -ra ./tests/test-addons.py
+          sudo -E venv/bin/pytest -s -ra ./tests/test-addons.py
           sudo snap remove microk8s --purge

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+pytest==8.3.4
+sh
+PyYaml
+requests


### PR DESCRIPTION
## Description

CI: Pins pytest to 8.3.4 for Test core addons

Currently, the "Test core addons" job fails because the ``test_cis`` test fails, having 2 more warnings than expected.

Those warnings are from ``microk8s kube-burner``, which has the following new warnings (the checks were passing before):

```
[WARN] 2.3 Ensure that the --auto-tls argument is not set to true (Automated)
[WARN] 2.6 Ensure that the --peer-auto-tls argument is not set to true (Automated)
```

Those warnings appear because the commands used for checking them fail:

```
2.3 audit test did not run: failed to run: "/bin/ps -ef | /bin/grep k8s-dqlite | /bin/grep -v grep", output: "", error: exit status 1
2.6 audit test did not run: failed to run: "/bin/ps -ef | /bin/grep k8s-dqlite | /bin/grep -v grep", output: "", error: exit status 1
```

Those errors would suggest that there is no ``k8s-dqlite`` process running on the node... but it should. In ``test_cis``, after enabling ``cis-hardening`` (``microk8s enable cis-hardening``) and before running ``microk8s kube-burner``, in the test we're waiting for Kubernetes to be available, accesible, and ready (``wait_for_installation``), which would only be possible if ``k8s-dqlite`` would be running. What's more, this issue does not occur when manually running the exact same commands as in the
GitHub action, even on the same GitHub Runners.

Pinning pytest to 8.3.4 seems to be solving the issue above (8.3.5 was released a few days ago).