### PR TITLE
[Backport 1.30] CI: use pyenv with pinned pytest 8.3.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,10 +18,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install -r tests/requirements.txt
       - name: Running addons tests
         run: |
           set -x
@@ -35,5 +35,5 @@ jobs:
             export STRICT="yes"
           fi
           export SKIP_PROMETHEUS="False"
-          sudo -E pytest -s -ra ./tests/test-addons.py
+          sudo -E venv/bin/pytest -s -ra ./tests/test-addons.py
           sudo snap remove microk8s --purge

--- a/addons/rook-ceph/plugin/.rook-create-external-cluster-resources.py
+++ b/addons/rook-ceph/plugin/.rook-create-external-cluster-resources.py
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+pytest==8.3.4
+sh
+PyYaml
+requests


### PR DESCRIPTION
## Description

Backport of https://github.com/canonical/microk8s-core-addons/pull/321