### PR TITLE
[1.28] fix: update ingress-nginx to 1.11.5 (#330)

### DIFF
--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -24,7 +24,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="v1.8.0"
+TAG="v1.11.5"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 


### PR DESCRIPTION
https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/
(cherry picked from commit 64b81b9b3545abd6eaf96e868f764202990a8d53)

