### PR TITLE
test: drop brittle assertions

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -458,14 +458,11 @@ def validate_cis_hardening():
     output = run_until_success("microk8s kube-bench")
 
     print(output)
-    assert "41 checks WARN" in output
     if os.environ.get("STRICT") == "yes":
-        assert "82 checks PASS" in output
         assert "1 checks FAIL" in output
     else:
         # The extra test that is failing on strict is the permissions of the
         # systemd kubelite service definition
-        assert "83 checks PASS" in output
         assert "0 checks FAIL" in output
 
 


### PR DESCRIPTION
"validate_cis_hardening" explicitly checks the number of warnings and successful tests, which is extremely brittle. The microk8s CI is currently failing because of this.

We'll loosen those assertions and only check for expected failures.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
