### PR TITLE
rook-ceph: Update addon to v1.16.6

### DIFF
--- a/addons/rook-ceph/README.md
+++ b/addons/rook-ceph/README.md
@@ -21,15 +21,13 @@ We should revisit this decision in the future. Ideally, we would want to avoid h
 
 #### `.rook-create-external-cluster-resources.py`
 
-Sourced from: https://github.com/rook/rook/blob/v1.11.9/deploy/examples/create-external-cluster-resources.py
+Sourced from: https://github.com/rook/rook/blob/v1.16.6/deploy/examples/create-external-cluster-resources.py
 
-This script is used to generate Ceph auth clients for use by the Ceph CSI node and provisioner pods. The following changes are applied:
-
-- (https://github.com/rook/rook/pull/12502) add '--keyring' argument to use custom Ceph keyring
+This script is used to generate Ceph auth clients for use by the Ceph CSI node and provisioner pods.
 
 #### `.rook-import-external-cluster.sh`
 
-Sourced from: https://github.com/rook/rook/blob/v1.11.9/deploy/examples/import-external-cluster.sh
+Sourced from: https://github.com/rook/rook/blob/v1.16.6/deploy/examples/import-external-cluster.sh
 
 This script is used to create the Kubernetes secrets and configmaps for connecting to an external Ceph cluster. The following changes are applied:
 

--- a/addons/rook-ceph/enable
+++ b/addons/rook-ceph/enable
@@ -25,7 +25,7 @@ ROOK_PLUGINS = [
 
 
 @click.command()
-@click.option("--rook-version", default="v1.11.9")
+@click.option("--rook-version", default="v1.16.6")
 @click.option("--rook-repository", default="https://charts.rook.io/release")
 @click.option("--set", "helm_set", multiple=True)
 @click.option("-f", "--values", "helm_values", multiple=True, type=click.Path(exists=True))

--- a/addons/rook-ceph/plugin/connect-external-ceph
+++ b/addons/rook-ceph/plugin/connect-external-ceph
@@ -106,9 +106,16 @@ def import_external_ceph_cluster(ceph_conf: str, keyring: str, namespace: str, r
         args += [f"--keyring={keyring}"]
 
     click.echo("Configuring Ceph CSI secrets")
-    p = subprocess.run(
-        [sys.executable, CREATE_EXTERNAL_CLUSTER_RESOURCES, *args], capture_output=True, check=True
-    )
+    try:
+        p = subprocess.run(
+            [sys.executable, CREATE_EXTERNAL_CLUSTER_RESOURCES, *args], capture_output=True, check=True
+        )
+    except subprocess.CalledProcessError as ex:
+        click.echo(f"{CREATE_EXTERNAL_CLUSTER_RESOURCES} failed")
+        click.echo(f"stdout: {ex.stdout.decode()}")
+        click.echo(f"stderr: {ex.stderr.decode()}")
+        raise
+
     click.echo("Successfully configured Ceph CSI secrets")
     bashvars = p.stdout.decode()
 

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -509,6 +509,12 @@ def validate_rook_ceph_integration():
 
             subprocess.check_call(f"microceph disk add --wipe /dev/sdi{l}".split())
 
+        # When connecting to an external Ceph and no monitoring endpoint is given,
+        # .rook-create-external-cluster-resources.py will try to detect it automatically.
+        # If none is found, an Exception is raised.
+        # We need to enable Prometheus for microceph.
+        subprocess.check_call("microceph.ceph mgr module enable prometheus".split())
+
         subprocess.check_call("ceph fs volume create fs0".split())
         subprocess.check_call("microk8s connect-external-ceph".split())
 


### PR DESCRIPTION
Reviewer notes regarding this update:
- `.rook-create-external-cluster-resources.py`: it now matches upstream's v1.16.6 script (the `--keyring` PR merged upstream, as well as IPv6 support).
- `connect-external-ceph`: if an error occurs while calling `.rook-create-external-cluster-resources.py`, we now log its `stdout` and `stderr`, which were not logged previously. This demystifies potentials errors.
- `validators.py`: in `validate_rook_ceph_integration`, we now enable `prometheus`, which is now required, as noted below.

Notable updates:
- `.rook-create-external-cluster-resources.py`: If a `--monitoring-endpoint` option is not given, the script will try to automatically find one. If it is not found, an `ExecutionFailureException` is now raised (it was not previously).

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
