### PR TITLE
nvidia: Update addon helm charts to the latest versions

### DIFF
--- a/addons/nvidia/disable
+++ b/addons/nvidia/disable
@@ -9,6 +9,17 @@ import click
 
 SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
 HELM = SNAP / "microk8s-helm3.wrapper"
+KUBECTL = SNAP / "microk8s-kubectl.wrapper"
+NVIDIA_CRDS = [
+    # gpu-operator CRDs.
+    "clusterpolicies.nvidia.com",
+    "nvidiadrivers.nvidia.com",
+    # network-operator CRDs.
+    "hostdevicenetworks.mellanox.com",
+    "ipoibnetworks.mellanox.com",
+    "macvlannetworks.mellanox.com",
+    "nicclusterpolicies.mellanox.com",
+]
 
 
 @click.command()
@@ -26,6 +37,9 @@ def main():
         if chart.get("name") in ["gpu-operator", "network-operator"]:
             namespace = chart.get("namespace") or "default"
             subprocess.run([HELM, "uninstall", name, "-n", namespace])
+
+    for crd in NVIDIA_CRDS:
+        subprocess.run([KUBECTL, "delete", "crd", crd])
 
     click.echo("NVIDIA support disabled")
 

--- a/addons/nvidia/enable
+++ b/addons/nvidia/enable
@@ -122,7 +122,7 @@ def deploy_gpu_operator(
 @click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, hidden=True, default=None)
 @click.option("--gpu-operator-set-as-default-runtime/--gpu-operator-no-set-as-default-runtime", is_flag=True, default=True)
 @click.option("--network-operator/--no-network-operator", is_flag=True, default=False)
-@click.option("--network-operator-version", default="23.7.0")
+@click.option("--network-operator-version", default="25.1.0")
 @click.option("--network-operator-set", multiple=True)
 @click.option("--network-operator-values", multiple=True, type=click.Path(exists=True))
 def main(
@@ -213,7 +213,7 @@ def main(
 
     # set default values
     if not gpu_operator_version:
-        gpu_operator_version = "v24.6.2"
+        gpu_operator_version = "v25.3.0"
 
     # add helm repository for nvidia gpu-operator and network-operator
     subprocess.run([HELM, "repo", "add", "nvidia", "https://helm.ngc.nvidia.com/nvidia"])


### PR DESCRIPTION
Updates the default version of the GPU operator to "v25.3.0". Updates the default version of the network operator to "25.1.0".

Clean up installed CRDs by the Helm charts when disabling addon.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
