### PR TITLE
[Backport 1.32] Fixes kube-ovn addon

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,11 @@ jobs:
           sudo microk8s status --wait-ready --timeout 600
           sudo microk8s addons repo remove core
           sudo microk8s addons repo add core .
+
+          # The GitHub runner is using the 10.1.0.0/16 CIDR, which would conflict with
+          # kube-ovn's default POD_CIDR. They have to be different.
+          export POD_CIDR="10.200.0.0/16"
+          export POD_GATEWAY="10.200.0.1"
           export UNDER_TIME_PRESSURE="True"
           if [[ "${{ matrix.channel }}" == "1.32-strict/edge" ]]
           then

--- a/addons/kube-ovn/disable
+++ b/addons/kube-ovn/disable
@@ -3,10 +3,15 @@
 # Sourced from: https://github.com/kubeovn/kube-ovn/blob/v1.12.21/dist/images/cleanup.sh
 # Changelog:
 # - use microk8s.$KUBECTL instead of $KUBECTL
+# - remove *-kube-ovn.conflist from $CNI_CONF_DIR
+# - restart the default CNI after disabling addon
+# - restart CodeDNS after disabling addon and reenabling default CNI
 
 set -eu
+source $SNAP/actions/common/utils.sh
 
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+CNI_CONF_DIR="/var/snap/microk8s/current/args/cni-network"
 
 $KUBECTL delete --ignore-not-found -n kube-system ds kube-ovn-pinger
 # ensure kube-ovn-pinger has been deleted
@@ -218,3 +223,20 @@ for ns in $($KUBECTL get ns -o name | awk -F/ '{print $2}'); do
   $KUBECTL annotate pod --all -n $ns ovn.kubernetes.io/network_type-
   $KUBECTL annotate pod --all -n $ns ovn.kubernetes.io/provider_network-
 done
+
+echo "Removing file $CNI_CONF_DIR/*-kube-ovn.conflist"
+run_with_sudo rm $CNI_CONF_DIR/*-kube-ovn.conflist || true
+
+if [ -e "$SNAP_DATA/args/cni-network/cni.yaml.backup" ]; then
+  echo "Restarting default CNI"
+  run_with_sudo mv "$SNAP_DATA/args/cni-network/cni.yaml.backup" "$SNAP_DATA/args/cni-network/cni.yaml"
+  $KUBECTL apply -f "$SNAP_DATA/args/cni-network/cni.yaml"
+
+  $KUBECTL wait --for=condition=Available -n kube-system deployment.apps/calico-kube-controllers
+  $KUBECTL wait --for=condition=Ready -n kube-system pod -l "k8s-app=calico-node"
+
+  echo "Rollout CoreDNS deployment with default CNI"
+  $KUBECTL -n kube-system rollout restart deployment/coredns
+  $KUBECTL -n kube-system rollout status deployment/coredns --timeout 300s
+  echo "NOTE: Other pods may need to be recreated for their network connectivity to be restored (CNI changed)"
+fi

--- a/addons/kube-ovn/enable
+++ b/addons/kube-ovn/enable
@@ -25,6 +25,37 @@ HOSTNAME = socket.gethostname()
 NO_AVX_CPU_TAG = "-no-avx512"
 
 
+def wait_for_resource_to_disappear(resource, name, label=None):
+    command = [KUBECTL, "get", resource, "-n", "kube-system", "--no-headers"]
+    if label:
+        command = command + ["-l", label]
+
+    timeout, elapsed = 120, 0
+    while True:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        lines = result.stdout.splitlines()
+        resources = [r for r in lines if name in r]
+
+        if not resources:
+            print(f"All {name} resource(s) have been cleaned up.")
+            break
+
+        print(
+            f"Still cleaning up {len(resources)} {name} resources(s)..."
+        )
+        if elapsed >= timeout:
+            print(
+                f"Failed to cleanup {len(resources)} remaining resource(s) in time, exiting."
+            )
+            return
+        time.sleep(5)
+        elapsed += 5
+
+
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--hostname", default=HOSTNAME, help="Host(s) to use for ovn-db")
 @click.option("--force", is_flag=True, default=False)
@@ -71,34 +102,18 @@ Error: kube-ovn requires ha-cluster to be enabled. Please enable with:
     # 2. disable calico
     cni_yaml = SNAP_DATA / "args" / "cni-network" / "cni.yaml"
     if cni_yaml.exists():
+        click.echo("Remove Calico kube-controllers and calico-node")
+        subprocess.run([KUBECTL, "delete", "-n", "kube-system", "daemonset.apps/calico-node"])
+        subprocess.run([KUBECTL, "delete", "-n", "kube-system", "deployment.apps/calico-kube-controllers"])
+
+        wait_for_resource_to_disappear("pod", "calico-node", "k8s-app=calico-node")
+        wait_for_resource_to_disappear("pod", "calico-kube-controllers", "k8s-app=calico-kube-controllers")
+
         click.echo("Remove Calico CNI")
         subprocess.run([KUBECTL, "delete", "-f", cni_yaml])
         shutil.move(cni_yaml, SNAP_DATA / "args" / "cni-network" / "cni.yaml.backup")
         print("Cleaning up Calico resources...")
-        timeout, elapsed = 120, 0
-        while True:
-            result = subprocess.run(
-                [KUBECTL, "get", "all", "-A", "--no-headers"],
-                stdout=subprocess.PIPE,
-                text=True,
-            )
-            resources = result.stdout.splitlines()
-            calico_resources = [r for r in resources if "calico" in r]
-
-            if not calico_resources:
-                print("All Calico resource(s) have been cleaned up.")
-                break
-
-            print(
-                f"Still cleaning up {len(calico_resources)} Calico resources(s)..."
-            )
-            if elapsed >= timeout:
-                print(
-                    f"Failed to cleanup {len(calico_resources)} remaining resource(s) in time, exiting."
-                )
-                return
-            time.sleep(5)
-            elapsed += 5
+        wait_for_resource_to_disappear("all", "calico")
 
     # Run kube-ovn install script
     click.echo("Run kube-ovn install script")

--- a/addons/kube-ovn/install.sh
+++ b/addons/kube-ovn/install.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # - template variable __REPLICAS__ for the ovn db replicas
 # - (2022-10-12) remove PodSecurityPolicy
 # - (2022-10-12) remove ovn-config ConfigMap
+# - (2025-04-09) add configurable POD_CIDR, POD_GATEWAY, SVC_CIDR, and JOIN_CIDR
 
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 
@@ -60,33 +61,33 @@ KUBELET_DIR="/var/snap/microk8s/current/var/lib/kubelet"
 LOG_DIR="/var/snap/microk8s/common/var/log"
 ORIGIN_DIR="/var/snap/microk8s/current/etc/origin"
 
-CNI_CONF_DIR="/var/snap/microk8s/current/etc/cni/net.d"
+CNI_CONF_DIR="/var/snap/microk8s/current/args/cni-network"
 CNI_BIN_DIR="/var/snap/microk8s/current/opt/cni/bin"
 
 REGISTRY="docker.io/kubeovn"
 VPC_NAT_IMAGE="vpc-nat-gateway"
 VERSION="v1.12.21"
 IMAGE_PULL_POLICY="IfNotPresent"
-POD_CIDR="10.1.0.0/16" # Do NOT overlap with NODE/SVC/JOIN CIDR
-POD_GATEWAY="10.1.0.1"
-SVC_CIDR="10.152.183.0/24"             # Do NOT overlap with NODE/POD/JOIN CIDR
-JOIN_CIDR="100.64.0.0/16"              # Do NOT overlap with NODE/POD/SVC CIDR
+POD_CIDR="${POD_CIDR:-10.1.0.0/16}"     # Do NOT overlap with NODE/SVC/JOIN CIDR
+POD_GATEWAY="${POD_GATEWAY:-10.1.0.1}"
+SVC_CIDR="${SVC_CIDR:-10.152.183.0/24}" # Do NOT overlap with NODE/POD/JOIN CIDR
+JOIN_CIDR="${JOIN_CIDR:-100.64.0.0/16}" # Do NOT overlap with NODE/POD/SVC CIDR
 PINGER_EXTERNAL_ADDRESS="1.1.1.1"      # Pinger check external ip probe
 PINGER_EXTERNAL_DOMAIN="canonical.com" # Pinger check external domain probe
 SVC_YAML_IPFAMILYPOLICY=""
 if [ "$IPV6" = "true" ]; then
-  POD_CIDR="fd00:10:16::/112" # Do NOT overlap with NODE/SVC/JOIN CIDR
-  POD_GATEWAY="fd00:10:16::1"
-  SVC_CIDR="fd00:10:96::/112"   # Do NOT overlap with NODE/POD/JOIN CIDR
-  JOIN_CIDR="fd00:100:64::/112" # Do NOT overlap with NODE/POD/SVC CIDR
+  POD_CIDR="${POD_CIDR:-fd00:10:16::/112}"    # Do NOT overlap with NODE/SVC/JOIN CIDR
+  POD_GATEWAY="${POD_GATEWAY:-fd00:10:16::1}"
+  SVC_CIDR="${SVC_CIDR:-fd00:10:96::/112}"    # Do NOT overlap with NODE/POD/JOIN CIDR
+  JOIN_CIDR="${JOIN_CIDR:-fd00:100:64::/112}" # Do NOT overlap with NODE/POD/SVC CIDR
   PINGER_EXTERNAL_ADDRESS="2400:3200::1"
   PINGER_EXTERNAL_DOMAIN="google.com."
 fi
 if [ "$DUAL_STACK" = "true" ]; then
-  POD_CIDR="10.1.0.0/16,fd00:10:16::/112" # Do NOT overlap with NODE/SVC/JOIN CIDR
-  POD_GATEWAY="10.1.0.1,fd00:10:16::1"
-  SVC_CIDR="10.152.183.0/24,fd00:10:96::/112" # Do NOT overlap with NODE/POD/JOIN CIDR
-  JOIN_CIDR="100.64.0.0/16,fd00:100:64::/112" # Do NOT overlap with NODE/POD/SVC CIDR
+  POD_CIDR="${POD_CIDR:-10.1.0.0/16,fd00:10:16::/112}"      # Do NOT overlap with NODE/SVC/JOIN CIDR
+  POD_GATEWAY="${POD_GATEWAY:-10.1.0.1,fd00:10:16::1}"
+  SVC_CIDR="${SVC_CIDR:-10.152.183.0/24,fd00:10:96::/112}"  # Do NOT overlap with NODE/POD/JOIN CIDR
+  JOIN_CIDR="${JOIN_CIDR:-100.64.0.0/16,fd00:100:64::/112}" # Do NOT overlap with NODE/POD/SVC CIDR
   PINGER_EXTERNAL_ADDRESS="114.114.114.114,2400:3200::1"
   PINGER_EXTERNAL_DOMAIN="google.com."
   SVC_YAML_IPFAMILYPOLICY="ipFamilyPolicy: PreferDualStack"

--- a/tests/templates/nginx-svc.yaml
+++ b/tests/templates/nginx-svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: nginx

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -18,6 +18,7 @@ from validators import (
     validate_metrics_server,
     validate_rbac,
     validate_metallb_config,
+    validate_networking,
     validate_observability,
     validate_coredns_config,
     validate_mayastor,
@@ -232,6 +233,27 @@ class TestAddons(object):
         validate_gpu()
         print("Disable gpu")
         microk8s_disable("gpu")
+
+    @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping kube-ovn tests in strict confinement as they are expected to fail",
+    )
+    def test_kube_ovn(self):
+        """
+        Test kube-ovn.
+        """
+
+        print("Enabling kube-ovn")
+        microk8s_enable("kube-ovn", force=True)
+
+        print("Validating kube-ovn")
+        validate_networking()
+
+        print("Disabling kube-ovn")
+        microk8s_disable("kube-ovn")
+
+        print("Validating default CNI networking")
+        validate_networking()
 
     @pytest.mark.skipif(
         platform.machine() != "x86_64",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -172,7 +172,7 @@ def wait_for_namespace_termination(namespace, timeout_insec=360):
         time.sleep(10)
 
 
-def microk8s_enable(addon, timeout_insec=300):
+def microk8s_enable(addon, timeout_insec=300, force=False):
     """
     Disable an addon
 
@@ -192,6 +192,8 @@ def microk8s_enable(addon, timeout_insec=300):
             raise CalledProcessError(1, "Nothing to do for gpu")
 
     cmd = "/snap/bin/microk8s.enable {}".format(addon)
+    if force:
+        cmd = "{} --force".format(cmd)
     return run_until_success(cmd, timeout_insec)
 
 


### PR DESCRIPTION
There are a few issues with the `kube-ovn` addon:
- While enabling, it may timeout while waiting for the Calico pods to disappear. This may happen if its service account / cluster role / cluster role binding gets deleted, it can no longer fetch `ClusterInformation`. We're now removing them beforehand, and waiting for them to disappear.
- The `CNI_CONF_DIR` should be `/var/snap/microk8s/current/args/cni-network`.
- When disabling, we should remove the `01-kube-ovn.conflist` file from `$CNI_CONF_DIR`, otherwise `kube-ovn` may be used for future pods, even though the `kube-ovn` addon is not enabled.
- When disabling, reenable the default CNI and rollout the CoreDNS deployment, so it can use the default CNI.

Adds kube-ovn addon test. The test will enable the `kube-ovn` addon and test the network connectivity by creating an nginx pod and service, and try to connect to that nginx through the cluster IP.

Afterwards, the test will disable the addon, and test the network connectivity again.

Fixes: https://github.com/canonical/microk8s/issues/5012

Backported from: https://github.com/canonical/microk8s-core-addons/pull/337

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
