### PR TITLE
feat: bump hostpath provisioner to 1.6.0

### DIFF
--- a/addons/hostpath-storage/storage.yaml
+++ b/addons/hostpath-storage/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner:1.5.0
+          image: cdkbot/hostpath-provisioner:1.6.0
           env:
             - name: NAMESPACE
               valueFrom:
@@ -81,6 +81,7 @@ rules:
       - update
       - watch
       - create
+      - patch
       - delete
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
Update addon for https://github.com/canonical/hostpath-provisioner/pull/13
