### PR TITLE
Use GPU Operator defaults for set-as-default-runtime

### DIFF
--- a/addons/nvidia/enable
+++ b/addons/nvidia/enable
@@ -87,8 +87,8 @@ def deploy_gpu_operator(
         },
     }
 
-    # We only set the default runtime if if is explicitly requested, otherwise
-    # the GPU operator is allowed to determine the correct valus based on its
+    # We only set the default runtime if it is explicitly requested, otherwise
+    # the GPU operator is allowed to determine the correct value based on its
     # other settings.
     if set_as_default_runtime is not None:
         helm_config["toolkit"]["env"].append({

--- a/addons/nvidia/enable
+++ b/addons/nvidia/enable
@@ -82,14 +82,20 @@ def deploy_gpu_operator(
             "env": [
                 {"name": "CONTAINERD_CONFIG", "value": CONTAINERD_TOML.as_posix()},
                 {"name": "CONTAINERD_SOCKET", "value": CONTAINERD_SOCKET.as_posix()},
-                {
-                    "name": "CONTAINERD_SET_AS_DEFAULT",
-                    "value": "1" if set_as_default_runtime else "0",
-                },
                 {"name": "RUNTIME_CONFIG_SOURCE", "value": f"file={RUNTIME_CONFIG_SOURCE.as_posix()}"}
             ],
         },
     }
+
+    # We only set the default runtime if if is explicitly requested, otherwise
+    # the GPU operator is allowed to determine the correct valus based on its
+    # other settings.
+    if set_as_default_runtime is not None:
+        helm_config["toolkit"]["env"].append({
+            "name": "CONTAINERD_SET_AS_DEFAULT",
+            "value": "1" if set_as_default_runtime else "0",
+        })
+
     if toolkit_version is not None:
         helm_config["toolkit"]["version"] = toolkit_version
 
@@ -122,7 +128,7 @@ def deploy_gpu_operator(
 @click.option("--toolkit-version", default=None, hidden=True)
 @click.option("--gpu-operator-toolkit-version", default=None)
 @click.option("--set-as-default-runtime/--no-set-as-default-runtime", is_flag=True, hidden=True, default=None)
-@click.option("--gpu-operator-set-as-default-runtime/--gpu-operator-no-set-as-default-runtime", is_flag=True, default=True)
+@click.option("--gpu-operator-set-as-default-runtime/--gpu-operator-no-set-as-default-runtime", is_flag=True, default=None)
 @click.option("--network-operator/--no-network-operator", is_flag=True, default=False)
 @click.option("--network-operator-version", default="25.7.0")
 @click.option("--network-operator-set", multiple=True)

--- a/tests/templates/cuda-add.yaml
+++ b/tests/templates/cuda-add.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cuda-vector-add
 spec:
   restartPolicy: OnFailure
+  runtimeClassName: nvidia
   containers:
     - name: cuda-vector-add
       # https://github.com/kubernetes/kubernetes/blob/v1.7.11/test/images/nvidia-cuda/Dockerfile


### PR DESCRIPTION
This change defaults to using the GPU Operator setting for the CONTAINERD_SET_AS_DEFAULT envvar when configuring the NVIDIA Container Toolkit. This allows for better integration with the GPU Operator in cases where this setting is expected to have a particular value.

See #360

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
