### PR TITLE
chore: branch out 1.34

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -2,9 +2,7 @@ name: Lint Code
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [1.34]
 
 jobs:
   check-formatting:

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -2,7 +2,7 @@ name: cla-check
 
 on:
   pull_request:
-    branches: [main, default]
+    branches: [1.34]
 
 jobs:
   cla-check:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,7 @@ name: Run tests
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [1.34]
 
 jobs:
   run-tests:
@@ -12,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        channel: [latest/edge, latest/edge/strict]
+        channel: [1.34/edge, 1.34-strict/edge]
 
     steps:
       - name: Check out code
@@ -37,7 +35,7 @@ jobs:
           export POD_CIDR="10.200.0.0/16"
           export POD_GATEWAY="10.200.0.1"
           export UNDER_TIME_PRESSURE="True"
-          if [[ "${{ matrix.channel }}" == "latest/edge/strict" ]]
+          if [[ "${{ matrix.channel }}" == "1.34-strict/edge" ]]
           then
             export STRICT="yes"
           fi


### PR DESCRIPTION
### chore: branch out 1.34

This PR branches out the 1.34 release.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
