### PR TITLE
fix: use new CLA signing standard

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
In February 2025 Canonical published a new CLA certificate signing process. Through this I (or any community member) is able to make PRs against community repos. This updates our workflow to use the new process.
