### PR TITLE
fix: Change Kubernetes Dashboard namespace to kube-system

### DIFF
--- a/addons/dashboard/disable
+++ b/addons/dashboard/disable
@@ -22,6 +22,9 @@ $KUBECTL delete configmap -n kube-system eventer-config  > /dev/null 2>&1 || tru
 $KUBECTL delete serviceaccount -n kube-system heapster  > /dev/null 2>&1 || true 
 
 HELM="$SNAP/microk8s-helm3.wrapper"
-$HELM uninstall -n kubernetes-dashboard kubernetes-dashboard
+echo "Removing kubernetes-dashboard from kube-system namespace"
+$HELM uninstall -n kube-system kubernetes-dashboard || true
+echo "Removing kubernetes-dashboard from kubernetes-dashboard namespace (backwards compatibility)"
+$HELM uninstall -n kubernetes-dashboard kubernetes-dashboard || true
 
 echo "Dashboard is disabled"

--- a/addons/dashboard/enable
+++ b/addons/dashboard/enable
@@ -51,7 +51,7 @@ HELM="$SNAP/microk8s-helm3.wrapper"
 echo "Enabling Kubernetes dashboard"
 $HELM upgrade --install kubernetes-dashboard kubernetes-dashboard \
   --repo "${REPO}" --version "${VERSION}" \
-  --create-namespace --namespace "kubernetes-dashboard"
+  --namespace "kube-system"
 
 echo "Applying manifest"
 use_addon_manifest dashboard/token-creation apply

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -28,7 +28,7 @@ def validate_dns_dashboard():
     Validate the dashboard addon by trying to access the kubernetes dashboard.
     The dashboard will return an HTML indicating that it is up and running.
     """
-    ns = "kubernetes-dashboard"
+    ns = "kube-system"
     components = ["api", "auth", "metrics-scraper", "web"]
     app_names = [f"kubernetes-dashboard-{app}" for app in components]
     app_names.append("kong")


### PR DESCRIPTION
### Overview

This PR changes the dashboard namespace to `kube-system`.