### PR TITLE
fix(ingress): Correct controler value in IngressClass 'nginx'

### DIFF
--- a/addons/ingress/values.yaml
+++ b/addons/ingress/values.yaml
@@ -75,4 +75,4 @@ extraObjects:
     metadata:
       name: nginx
     spec:
-      controller: traefik.io/ingress-controller
+      controller: k8s.io/ingress-nginx

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -203,6 +203,12 @@ def validate_ingress():
     kubectl("apply -f {}".format(manifest))
     wait_for_pod_state("", "default", "running", label="app=microbot")
 
+    # Verify there is a IngressClass with name "nginx" and the correct controller
+    # see https://github.com/canonical/microk8s-core-addons/issues/381
+    nginxIngressClass = kubectl_get("ingressclass nginx")
+    assert nginxIngressClass is not None
+    assert nginxIngressClass["spec"]["controller"] == "k8s.io/ingress-nginx"
+
     common_ingress()
 
     kubectl("delete -f {}".format(manifest))


### PR DESCRIPTION
This PR set the correct controller in the nginx `IngressClass` created by the ingress add-on.

Fixes canonical/microk8s-core-addons#381

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
