### PR TITLE
fix(ingress): Remove unneeded loadbalancer service

### DIFF
--- a/addons/ingress/values.yaml
+++ b/addons/ingress/values.yaml
@@ -5,6 +5,10 @@
 deployment:
   kind: DaemonSet
 
+# Do not create service (matching previous nginx behavior)
+service:
+  enabled: false
+
 # Expose ports on host (matching previous nginx behavior)
 ports:
   web:


### PR DESCRIPTION
This PR remove the unneeded loadbalancer service created when ingress add-on is deployed.

Fixes canonical/microk8s-core-addons#383

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
