### PR TITLE
ci: restrict /backport comment trigger to repo members

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -25,6 +25,9 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 99445902 &&
+        (github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'COLLABORATOR') &&
         contains(github.event.comment.body, '/backport')
       )
     steps:


### PR DESCRIPTION
## Summary

The `issue_comment` trigger in this backport workflow runs with elevated permissions (`contents: write`, `pull-requests: write`, `BOT_TOKEN`). Previously any GitHub user could trigger it by commenting `/backport` on any PR.

This adds an `author_association` guard so only `MEMBER`, `OWNER`, or `COLLABORATOR` accounts can trigger a backport via comment.

## Change

```yaml
# Before
github.event.comment.user.id != 99445902 &&
contains(github.event.comment.body, '/backport')

# After
github.event.comment.user.id != 99445902 &&
(github.event.comment.author_association == 'MEMBER' ||
 github.event.comment.author_association == 'OWNER' ||
 github.event.comment.author_association == 'COLLABORATOR') &&
contains(github.event.comment.body, '/backport')
```

## References
- [Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
