### PR TITLE
fix: Fix expected output in README for CIS checks

### DIFF
--- a/addons/cis-hardening/README.md
+++ b/addons/cis-hardening/README.md
@@ -375,7 +375,7 @@ find /var/snap/microk8s/current/args/cni-network/10-calico.conflist -type f 2> /
 Expected output:
 
 ```
-root:toot
+root:root
 ```
 
 ### Check 1.1.11
@@ -443,7 +443,7 @@ stat -c %U:%G /var/snap/microk8s/current/var/kubernetes/backend/
 Expected output:
 
 ```
-root:toot
+root:root
 ```
 
 ### Check 1.1.13


### PR DESCRIPTION
Correct expected output for checks 1.1.10 and 1.1.12 (root:toot --> root:root)

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
