### PR TITLE
chore: branch out 1.35

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -2,9 +2,7 @@ name: Lint Code
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [1.35]
 
 jobs:
   check-formatting:

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -2,7 +2,7 @@ name: cla-check
 
 on:
   pull_request:
-    branches: [main, default]
+    branches: [1.35]
 
 jobs:
   cla-check:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,7 @@ name: Run tests
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [1.35]
 
 jobs:
   run-tests:
@@ -13,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [latest/edge, latest/edge/strict]
+        channel: [1.35/edge, 1.35-strict/edge]
 
     steps:
       - name: Check out code
@@ -38,7 +36,7 @@ jobs:
           export POD_CIDR="10.200.0.0/16"
           export POD_GATEWAY="10.200.0.1"
           export UNDER_TIME_PRESSURE="True"
-          if [[ "${{ matrix.channel }}" == "latest/edge/strict" ]]
+          if [[ "${{ matrix.channel }}" == "1.35-strict/edge" ]]
           then
             export STRICT="yes"
           fi


### PR DESCRIPTION
#### chore: branch out 1.35

This PR branches out the 1.35 release for core addons.

Changes:
- CI workflows target `1.35` branch instead of `main`
- Removed `push:` triggers (only `pull_request:` on release branch)
- Test matrix uses `1.35/edge` and `1.35-strict/edge` snap channels

#### Checklist

* [x] Read the contributions page.
* [x] Submitted the CLA form.