### PR TITLE
feat: bump addon versions for 1.36 release

### DIFF
--- a/addons/cert-manager/enable
+++ b/addons/cert-manager/enable
@@ -7,7 +7,7 @@ ENABLE="$SNAP/microk8s-enable.wrapper"
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 
 REPO="https://charts.jetstack.io"
-VERSION="v1.19.1"
+VERSION="v1.20.2"
 
 function usage {
   echo "Usage: microk8s enable cert-manager [OPTIONS]"

--- a/addons/dns/coredns.yaml
+++ b/addons/dns/coredns.yaml
@@ -83,7 +83,7 @@ spec:
                 path: Corefile
       containers:
         - name: coredns
-          image: coredns/coredns:1.13.1
+          image: coredns/coredns:1.14.3
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -103,6 +103,14 @@ $HELM repo update traefik
 echo "Installing Gateway API CRDs"
 $KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
 
+echo "Installing Traefik CRDs"
+TRAEFIK_CRD_DIR=$(mktemp -d)
+$HELM pull traefik/traefik --version "${CHART_VERSION}" --untar --untardir "${TRAEFIK_CRD_DIR}"
+for crd in "${TRAEFIK_CRD_DIR}"/traefik/crds/traefik.io_*.yaml; do
+    $KUBECTL apply --server-side -f "${crd}"
+done
+rm -rf "${TRAEFIK_CRD_DIR}"
+
 echo "Installing Traefik ingress controller"
 $HELM upgrade --install traefik traefik/traefik \
     --version "${CHART_VERSION}" \

--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -100,15 +100,16 @@ echo "Adding Traefik Helm repository"
 $HELM repo add traefik "$REPO"
 $HELM repo update traefik
 
+echo "Installing Gateway API CRDs"
+$KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
+
 echo "Installing Traefik ingress controller"
 $HELM upgrade --install traefik traefik/traefik \
     --version "${CHART_VERSION}" \
     --create-namespace \
     --namespace "${NAMESPACE}" \
+    --skip-crds \
     --values "${CURRENT_DIR}/values.yaml"
-
-echo "Installing Gateway API CRDs"
-$KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
 
 if [[ -n "${DEFAULT_SSL_CERTIFICATE}" ]]; then
     echo "Configuring Traefik default TLS certificate (${DEFAULT_SSL_CERTIFICATE})"

--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -5,8 +5,8 @@ set -e
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 REPO="https://traefik.github.io/charts"
-CHART_VERSION="37.4.0"  # contains Traefik v3.6.2
-GW_VERSION="v1.4.0"
+CHART_VERSION="39.0.8"  # contains Traefik v3.6.13
+GW_VERSION="v1.5.1"
 NAMESPACE="ingress"
 DEFAULT_SSL_CERTIFICATE=""
 

--- a/addons/metallb/metallb.yaml
+++ b/addons/metallb/metallb.yaml
@@ -464,7 +464,7 @@ spec:
           value: memberlist
         - name: METALLB_DEPLOYMENT
           value: controller
-        image: quay.io/metallb/controller:v0.15.2
+        image: quay.io/metallb/controller:v0.15.3
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -561,7 +561,7 @@ spec:
           value: app=metallb,component=speaker
         - name: METALLB_ML_SECRET_KEY_PATH
           value: /etc/ml_secret_key
-        image: quay.io/metallb/speaker:v0.15.2
+        image: quay.io/metallb/speaker:v0.15.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/addons/metrics-server/metrics-server.yaml
+++ b/addons/metrics-server/metrics-server.yaml
@@ -138,7 +138,7 @@ spec:
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
             - --kubelet-insecure-tls # ignore kubelet cert
-          image: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+          image: registry.k8s.io/metrics-server/metrics-server:v0.8.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
Bump core addon versions for the 1.36 MicroK8s release.

## Changes

| Addon | Previous | New |
|---|---|---|
| CoreDNS | 1.13.1 | **1.14.3** |
| Metrics Server | v0.8.0 | **v0.8.1** |
| Cert-Manager | v1.19.1 | **v1.20.2** |
| MetalLB | v0.15.2 | **v0.15.3** |
| Traefik Ingress | chart 37.4.0 (Traefik v3.6.2) | **chart 39.0.8** (Traefik v3.6.13) |
| Gateway API CRDs | v1.4.0 | **v1.5.1** |

To be removed in a separate PR Dashboard (chart 7.14.0).

## Notes

- Traefik chart 37→39 is a notable jump (two chart major versions) — CI should be watched closely
- All versions verified against upstream releases on 2026-04-28