### PR TITLE
test: update CIS check counts after 4.1.1 permission fix in strict snap

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -464,14 +464,13 @@ def validate_cis_hardening():
 
     print(output)
     assert "41 checks WARN" in output
-    if os.environ.get("STRICT") == "yes":
-        assert "82 checks PASS" in output
-        assert "1 checks FAIL" in output
-    else:
-        # The extra test that is failing on strict is the permissions of the
-        # systemd kubelite service definition
-        assert "83 checks PASS" in output
-        assert "0 checks FAIL" in output
+    # Check 4.1.1 ("kubelet service file permissions ≤ 600") used to FAIL in
+    # strict mode because snapd generated the snap.microk8s.daemon-kubelite.service
+    # unit file with 644 permissions.  That was fixed in the latest/edge/strict
+    # snap (observed passing as of 2026-04-13).  Both strict and non-strict now
+    # report identical totals.
+    assert "83 checks PASS" in output
+    assert "0 checks FAIL" in output
 
 
 def validate_rook_ceph():


### PR DESCRIPTION
## Summary

CIS strict test has been failing on `main` since 2026-04-13 with:

```
AssertionError: assert "82 checks PASS" in output
```

## Root cause

The assertion used separate expected counts for strict vs non-strict mode because check **4.1.1** ("kubelet service file permissions ≤ 600") used to **FAIL** in strict mode. The `snap.microk8s.daemon-kubelite.service` unit file was generated by snapd with `644` permissions — not restrictive enough to satisfy kube-bench's bitmask check against `600`.

This was **fixed in the `latest/edge/strict` snap channel** between 2026-04-08 and 2026-04-13 (no code change in this repo caused it). The check now passes in both strict and non-strict:

| Date | Run | strict PASS | strict FAIL |
|------|-----|-------------|-------------|
| 2026-04-08 | [last green](https://github.com/canonical/microk8s-core-addons/actions/runs/24136115231) | 82 | 1 (4.1.1) |
| 2026-04-28 | current | 83 | 0 |

## Change

Remove the strict/non-strict branch in `validate_cis_hardening()` — both modes now report `83 checks PASS / 0 checks FAIL / 41 checks WARN`. The comment explaining the historical difference is replaced with a note documenting when and why the fix landed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
