### PR TITLE
Depreciation: add deprecation warning to dashboard addon

### DIFF
--- a/addons/dashboard/disable
+++ b/addons/dashboard/disable
@@ -6,6 +6,9 @@ source $SNAP/actions/common/utils.sh
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 source $CURRENT_DIR/../common/utils.sh
 
+echo "DEPRECATION WARNING: 'dashboard' is deprecated and will be removed in 1.36."
+echo ""
+
 echo "Disabling Dashboard"
 
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"

--- a/addons/dashboard/enable
+++ b/addons/dashboard/enable
@@ -6,6 +6,9 @@ source $SNAP/actions/common/utils.sh
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 source $CURRENT_DIR/../common/utils.sh
 
+echo "DEPRECATION WARNING: 'dashboard' is deprecated and will be removed in 1.36."
+echo ""
+
 REPO="https://kubernetes-retired.github.io/dashboard/"
 VERSION="7.14.0"
 


### PR DESCRIPTION
## Summary

Add deprecation warning to the dashboard addon's enable and disable scripts. Users will now see a clear warning that this addon is deprecated and will be removed in 1.36.

## Changes

- addons/dashboard/enable: Print deprecation warning before enabling
- addons/dashboard/disable: Print deprecation warning before disabling

## Acceptance Criteria

- [x] dashboard addon emits a deprecation warning on enable
- [x] dashboard addon emits a deprecation warning on disable

## Notes

The dashboard addon is being removed in 1.36. This provides users one release cycle of warning to migrate.