### PR TITLE
test: add runtimeClassName nvidia to cuda-vector-add template

### DIFF
--- a/tests/templates/cuda-add.yaml
+++ b/tests/templates/cuda-add.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cuda-vector-add
 spec:
   restartPolicy: OnFailure
+  runtimeClassName: nvidia
   containers:
     - name: cuda-vector-add
       # https://github.com/kubernetes/kubernetes/blob/v1.7.11/test/images/nvidia-cuda/Dockerfile


### PR DESCRIPTION
## Summary

The `nvidia` addon no longer sets the nvidia runtime as the global default containerd runtime (the default is now `None`, delegating that decision to the GPU operator). As a result, pods that request GPU resources must explicitly opt-in via `runtimeClassName: nvidia`.

The existing `cuda-add.yaml` test template was missing this field, causing `CrashLoopBackOff` with:
```
Failed to allocate device vector A (error code CUDA driver version is insufficient for CUDA runtime version)!
```

This change adds `runtimeClassName: nvidia` to the template so the test works with the updated addon defaults.

## Testing

Validated on AWS g4dn.xlarge (Tesla T4, Ubuntu 22.04, MicroK8s 1.32/stable) against the `use-operator-defaults-for-set-as-default` branch:

**Without `runtimeClassName`:** ❌ CrashLoopBackOff  
**With `runtimeClassName: nvidia`:** ✅ `Test PASSED`
