### PR TITLE
fix(ingress): remove gateway-api ValidatingAdmissionPolicy after CRD install

### DIFF
--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -103,6 +103,12 @@ $HELM repo update traefik
 echo "Installing Gateway API CRDs"
 $KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
 
+# Remove the ValidatingAdmissionPolicy that blocks other addons from installing
+# older gateway-api CRDs bundled in their Helm charts (e.g. STUNner).
+# See: https://gateway-api.sigs.k8s.io/guides/#safe-upgrades
+$KUBECTL delete validatingadmissionpolicybinding safe-upgrades.gateway.networking.k8s.io --ignore-not-found
+$KUBECTL delete validatingadmissionpolicy safe-upgrades.gateway.networking.k8s.io --ignore-not-found
+
 echo "Installing Traefik CRDs"
 TRAEFIK_CRD_DIR=$(mktemp -d)
 $HELM pull traefik/traefik --version "${CHART_VERSION}" --untar --untardir "${TRAEFIK_CRD_DIR}"


### PR DESCRIPTION
## Problem

Gateway API v1.5.x (installed by the ingress addon since PR #396) ships a `ValidatingAdmissionPolicy` called `safe-upgrades.gateway.networking.k8s.io` that blocks any CRD creation/update in the `gateway.networking.k8s.io` group if the CRD's `bundle-version` annotation is < v1.5.0.

This breaks community addons (e.g. STUNner) whose Helm charts bundle older gateway-api CRDs internally. The error:

```
customresourcedefinitions.apiextensions.k8s.io "gatewayclasses.gateway.networking.k8s.io" is forbidden:
ValidatingAdmissionPolicy 'safe-upgrades.gateway.networking.k8s.io' with binding
'safe-upgrades.gateway.networking.k8s.io' denied request: Installing CRDs with version before v1.5.0
is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io
to install older versions.
```

## Fix

Remove the VAP and its binding immediately after installing Gateway API CRDs. This is safe because:

1. The v1.5.1 CRDs remain installed and Kubernetes won't downgrade them when other charts attempt to install older versions (CRD versions are additive)
2. The VAP is a safety guard designed for multi-tenant clusters to prevent accidental downgrades — it's not useful for MicroK8s (single-node, typically single-user)
3. This is exactly what the error message itself recommends

## Testing

- [ ] Enable ingress addon
- [ ] Enable STUNner community addon (which bundles gateway-api v1.4.1 CRDs)
- [ ] Verify gateway-api CRDs remain at v1.5.1 after STUNner install