### PR TITLE
ingress: configurable Gateway API CRDs URL for air-gapped environments

### DIFF
--- a/addons/ingress/disable
+++ b/addons/ingress/disable
@@ -3,7 +3,8 @@
 set -e
 
 NAMESPACE="ingress"
-GW_VERSION="v1.4.0"
+GW_VERSION="v1.5.1"
+GW_CRDS_URL=""
 
 function usage {
     echo "Usage: microk8s disable ingress [OPTIONS]"
@@ -11,18 +12,36 @@ function usage {
     echo "Disable the Traefik ingress controller addon."
     echo ""
     echo "   -h               Print this help message"
+    echo "   --gateway-api-crds-url URL"
+    echo "                    URL or path to the Gateway API CRDs YAML used during install"
 }
 
-while getopts ":h" arg; do
-    case "${arg}" in
-        h)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --gateway-api-crds-url)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Missing argument for option --gateway-api-crds-url"
+                usage
+                exit 1
+            fi
+            GW_CRDS_URL="$2"
+            shift 2
+            ;;
+        -h|--help)
             usage
             exit 0
             ;;
-        ?)
-            echo "Invalid option -${OPTARG}"
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "Invalid option $1"
             usage
             exit 1
+            ;;
+        *)
+            break
             ;;
     esac
 done
@@ -49,8 +68,11 @@ echo "Uninstalling Traefik..."
 $HELM uninstall traefik -n "${NAMESPACE}" 2>/dev/null || true
 
 # Delete Gateway API CRDs
+if [[ -z "${GW_CRDS_URL}" ]]; then
+    GW_CRDS_URL="https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
+fi
 echo "Removing Gateway API CRDs..."
-$KUBECTL delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml" 2>/dev/null || true
+$KUBECTL delete -f "${GW_CRDS_URL}" 2>/dev/null || true
 
 # Clean up Traefik CRDs
 echo "Cleaning up Traefik CRDs..."

--- a/addons/ingress/enable
+++ b/addons/ingress/enable
@@ -7,6 +7,7 @@ CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 REPO="https://traefik.github.io/charts"
 CHART_VERSION="39.0.8"  # contains Traefik v3.6.13
 GW_VERSION="v1.5.1"
+GW_CRDS_URL=""
 NAMESPACE="ingress"
 DEFAULT_SSL_CERTIFICATE=""
 
@@ -19,6 +20,8 @@ function usage {
     echo "   -r REPOSITORY    Traefik Helm chart repository (default: ${REPO})"
     echo "   -V VERSION       Traefik Helm chart version (default: ${CHART_VERSION})"
     echo "   -g GW_VERSION    Gateway API CRD version (default: ${GW_VERSION})"
+    echo "   --gateway-api-crds-url URL"
+    echo "                    URL or path to the Gateway API CRDs YAML (default: GitHub release for GW_VERSION)"
     echo "   --default-ssl-certificate NAMESPACE/NAME"
     echo "                    Kubernetes TLS Secret to use as Traefik's default TLS certificate"
 }
@@ -50,6 +53,15 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             GW_VERSION="$2"
+            shift 2
+            ;;
+        --gateway-api-crds-url)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Missing argument for option --gateway-api-crds-url"
+                usage
+                exit 1
+            fi
+            GW_CRDS_URL="$2"
             shift 2
             ;;
         --default-ssl-certificate)
@@ -100,8 +112,12 @@ echo "Adding Traefik Helm repository"
 $HELM repo add traefik "$REPO"
 $HELM repo update traefik
 
+if [[ -z "${GW_CRDS_URL}" ]]; then
+    GW_CRDS_URL="https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
+fi
+
 echo "Installing Gateway API CRDs"
-$KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_VERSION}/standard-install.yaml"
+$KUBECTL apply -f "${GW_CRDS_URL}"
 
 echo "Installing Traefik CRDs"
 TRAEFIK_CRD_DIR=$(mktemp -d)


### PR DESCRIPTION
What: Add --gateway-api-crds-url option to enable and [disable](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) scripts.

Why: The hardcoded GitHub URL for Gateway API CRDs fails in locked-down/air-gapped environments.

How: New CLI flag overrides the default URL; falls back to the GitHub release if unset. Also fixes mismatched GW_VERSION in [disable](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (v1.4.0 → v1.5.1).

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
