### PR TITLE
Set the correct Ingress Controller for nginx IngressClass for Traefik emulation

### DIFF
--- a/addons/ingress/values.yaml
+++ b/addons/ingress/values.yaml
@@ -75,4 +75,4 @@ extraObjects:
     metadata:
       name: nginx
     spec:
-      controller: traefik.io/ingress-controller
+      controller: k8s.io/ingress-nginx


### PR DESCRIPTION
fixes https://github.com/canonical/microk8s/issues/5473

To enable the Nginx annotation mode, the controller must match what is passed on the command line

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
