### PR TITLE
Add missing configurationstates CRD for MetalLB v0.15.3

### DIFF
--- a/addons/metallb/crd.yaml
+++ b/addons/metallb/crd.yaml
@@ -15,111 +15,111 @@ spec:
     singular: bfdprofile
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.passiveMode
-      name: Passive Mode
-      type: boolean
-    - jsonPath: .spec.transmitInterval
-      name: Transmit Interval
-      type: integer
-    - jsonPath: .spec.receiveInterval
-      name: Receive Interval
-      type: integer
-    - jsonPath: .spec.detectMultiplier
-      name: Multiplier
-      type: integer
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          BFDProfile represents the settings of the bfd session that can be
-          optionally associated with a BGP session.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BFDProfileSpec defines the desired state of BFDProfile.
-            properties:
-              detectMultiplier:
-                description: |-
-                  Configures the detection multiplier to determine
-                  packet loss. The remote transmission interval will be multiplied
-                  by this value to determine the connection loss detection timer.
-                format: int32
-                maximum: 255
-                minimum: 2
-                type: integer
-              echoInterval:
-                description: |-
-                  Configures the minimal echo receive transmission
-                  interval that this system is capable of handling in milliseconds.
-                  Defaults to 50ms
-                format: int32
-                maximum: 60000
-                minimum: 10
-                type: integer
-              echoMode:
-                description: |-
-                  Enables or disables the echo transmission mode.
-                  This mode is disabled by default, and not supported on multi
-                  hops setups.
-                type: boolean
-              minimumTtl:
-                description: |-
-                  For multi hop sessions only: configure the minimum
-                  expected TTL for an incoming BFD control packet.
-                format: int32
-                maximum: 254
-                minimum: 1
-                type: integer
-              passiveMode:
-                description: |-
-                  Mark session as passive: a passive session will not
-                  attempt to start the connection and will wait for control packets
-                  from peer before it begins replying.
-                type: boolean
-              receiveInterval:
-                description: |-
-                  The minimum interval that this system is capable of
-                  receiving control packets in milliseconds.
-                  Defaults to 300ms.
-                format: int32
-                maximum: 60000
-                minimum: 10
-                type: integer
-              transmitInterval:
-                description: |-
-                  The minimum transmission interval (less jitter)
-                  that this system wants to use to send BFD control packets in
-                  milliseconds. Defaults to 300ms
-                format: int32
-                maximum: 60000
-                minimum: 10
-                type: integer
-            type: object
-          status:
-            description: BFDProfileStatus defines the observed state of BFDProfile.
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.passiveMode
+          name: Passive Mode
+          type: boolean
+        - jsonPath: .spec.transmitInterval
+          name: Transmit Interval
+          type: integer
+        - jsonPath: .spec.receiveInterval
+          name: Receive Interval
+          type: integer
+        - jsonPath: .spec.detectMultiplier
+          name: Multiplier
+          type: integer
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            BFDProfile represents the settings of the bfd session that can be
+            optionally associated with a BGP session.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BFDProfileSpec defines the desired state of BFDProfile.
+              properties:
+                detectMultiplier:
+                  description: |-
+                    Configures the detection multiplier to determine
+                    packet loss. The remote transmission interval will be multiplied
+                    by this value to determine the connection loss detection timer.
+                  format: int32
+                  maximum: 255
+                  minimum: 2
+                  type: integer
+                echoInterval:
+                  description: |-
+                    Configures the minimal echo receive transmission
+                    interval that this system is capable of handling in milliseconds.
+                    Defaults to 50ms
+                  format: int32
+                  maximum: 60000
+                  minimum: 10
+                  type: integer
+                echoMode:
+                  description: |-
+                    Enables or disables the echo transmission mode.
+                    This mode is disabled by default, and not supported on multi
+                    hops setups.
+                  type: boolean
+                minimumTtl:
+                  description: |-
+                    For multi hop sessions only: configure the minimum
+                    expected TTL for an incoming BFD control packet.
+                  format: int32
+                  maximum: 254
+                  minimum: 1
+                  type: integer
+                passiveMode:
+                  description: |-
+                    Mark session as passive: a passive session will not
+                    attempt to start the connection and will wait for control packets
+                    from peer before it begins replying.
+                  type: boolean
+                receiveInterval:
+                  description: |-
+                    The minimum interval that this system is capable of
+                    receiving control packets in milliseconds.
+                    Defaults to 300ms.
+                  format: int32
+                  maximum: 60000
+                  minimum: 10
+                  type: integer
+                transmitInterval:
+                  description: |-
+                    The minimum transmission interval (less jitter)
+                    that this system wants to use to send BFD control packets in
+                    milliseconds. Defaults to 300ms
+                  format: int32
+                  maximum: 60000
+                  minimum: 10
+                  type: integer
+              type: object
+            status:
+              description: BFDProfileStatus defines the observed state of BFDProfile.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -136,207 +136,215 @@ spec:
     singular: bgpadvertisement
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.ipAddressPools
-      name: IPAddressPools
-      type: string
-    - jsonPath: .spec.ipAddressPoolSelectors
-      name: IPAddressPool Selectors
-      type: string
-    - jsonPath: .spec.peers
-      name: Peers
-      type: string
-    - jsonPath: .spec.nodeSelectors
-      name: Node Selectors
-      priority: 10
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          BGPAdvertisement allows to advertise the IPs coming
-          from the selected IPAddressPools via BGP, setting the parameters of the
-          BGP Advertisement.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BGPAdvertisementSpec defines the desired state of BGPAdvertisement.
-            properties:
-              aggregationLength:
-                default: 32
-                description: The aggregation-length advertisement option lets you
-                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
-                  IPv4 addresses.
-                format: int32
-                minimum: 1
-                type: integer
-              aggregationLengthV6:
-                default: 128
-                description: The aggregation-length advertisement option lets you
-                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
-                  for IPv6 addresses.
-                format: int32
-                type: integer
-              communities:
-                description: |-
-                  The BGP communities to be associated with the announcement. Each item can be a standard community of the
-                  form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
-                  Community CRD.
-                items:
-                  type: string
-                type: array
-              ipAddressPoolSelectors:
-                description: |-
-                  A selector for the IPAddressPools which would get advertised via this advertisement.
-                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.ipAddressPools
+          name: IPAddressPools
+          type: string
+        - jsonPath: .spec.ipAddressPoolSelectors
+          name: IPAddressPool Selectors
+          type: string
+        - jsonPath: .spec.peers
+          name: Peers
+          type: string
+        - jsonPath: .spec.nodeSelectors
+          name: Node Selectors
+          priority: 10
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            BGPAdvertisement allows to advertise the IPs coming
+            from the selected IPAddressPools via BGP, setting the parameters of the
+            BGP Advertisement.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPAdvertisementSpec defines the desired state of BGPAdvertisement.
+              properties:
+                aggregationLength:
+                  default: 32
+                  description:
+                    The aggregation-length advertisement option lets you
+                    “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                    IPv4 addresses.
+                  format: int32
+                  minimum: 1
+                  type: integer
+                aggregationLengthV6:
+                  default: 128
+                  description:
+                    The aggregation-length advertisement option lets you
+                    “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                    for IPv6 addresses.
+                  format: int32
+                  type: integer
+                communities:
                   description: |-
-                    A label selector is a label query over a set of resources. The result of matchLabels and
-                    matchExpressions are ANDed. An empty label selector matches all objects. A null
-                    label selector matches no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
-              ipAddressPools:
-                description: The list of IPAddressPools to advertise via this advertisement,
-                  selected by name.
-                items:
-                  type: string
-                type: array
-              localPref:
-                description: |-
-                  The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
-                  Path with higher localpref is preferred over one with lower localpref.
-                format: int32
-                type: integer
-              nodeSelectors:
-                description: NodeSelectors allows to limit the nodes to announce as
-                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
-                  announced as next hops.
-                items:
+                    The BGP communities to be associated with the announcement. Each item can be a standard community of the
+                    form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
+                    Community CRD.
+                  items:
+                    type: string
+                  type: array
+                ipAddressPoolSelectors:
                   description: |-
-                    A label selector is a label query over a set of resources. The result of matchLabels and
-                    matchExpressions are ANDed. An empty label selector matches all objects. A null
-                    label selector matches no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
+                    A selector for the IPAddressPools which would get advertised via this advertisement.
+                    If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description:
+                          matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description:
+                                key is the label key that the selector applies
+                                to.
                               type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                        - key
-                        - operator
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
-              peers:
-                description: |-
-                  Peers limits the bgppeer to advertise the ips of the selected pools to.
-                  When empty, the loadbalancer IP is announced to all the BGPPeers configured.
-                items:
-                  type: string
-                type: array
-            type: object
-          status:
-            description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                ipAddressPools:
+                  description:
+                    The list of IPAddressPools to advertise via this advertisement,
+                    selected by name.
+                  items:
+                    type: string
+                  type: array
+                localPref:
+                  description: |-
+                    The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
+                    Path with higher localpref is preferred over one with lower localpref.
+                  format: int32
+                  type: integer
+                nodeSelectors:
+                  description:
+                    NodeSelectors allows to limit the nodes to announce as
+                    next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                    announced as next hops.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description:
+                          matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description:
+                                key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                peers:
+                  description: |-
+                    Peers limits the bgppeer to advertise the ips of the selected pools to.
+                    When empty, the loadbalancer IP is announced to all the BGPPeers configured.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            status:
+              description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -354,8 +362,8 @@ spec:
           namespace: metallb-system
           path: /convert
       conversionReviewVersions:
-      - v1beta1
-      - v1beta2
+        - v1beta1
+        - v1beta2
   group: metallb.io
   names:
     kind: BGPPeer
@@ -364,354 +372,364 @@ spec:
     singular: bgppeer
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.peerAddress
-      name: Address
-      type: string
-    - jsonPath: .spec.peerASN
-      name: ASN
-      type: string
-    - jsonPath: .spec.bfdProfile
-      name: BFD Profile
-      type: string
-    - jsonPath: .spec.ebgpMultiHop
-      name: Multi Hops
-      type: string
-    deprecated: true
-    deprecationWarning: v1beta1 is deprecated, please use v1beta2
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: BGPPeer is the Schema for the peers API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BGPPeerSpec defines the desired state of Peer.
-            properties:
-              bfdProfile:
-                type: string
-              ebgpMultiHop:
-                description: EBGP peer is multi-hops away
-                type: boolean
-              holdTime:
-                description: Requested BGP hold time, per RFC4271.
-                type: string
-              keepaliveTime:
-                description: Requested BGP keepalive time, per RFC4271.
-                type: string
-              myASN:
-                description: AS number to use for the local end of the session.
-                format: int32
-                maximum: 4294967295
-                minimum: 0
-                type: integer
-              nodeSelectors:
-                description: |-
-                  Only connect to this peer on nodes that match one of these
-                  selectors.
-                items:
-                  properties:
-                    matchExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          values:
-                            items:
-                              type: string
-                            minItems: 1
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        - values
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                type: array
-              password:
-                description: Authentication password for routers enforcing TCP MD5
-                  authenticated sessions
-                type: string
-              peerASN:
-                description: AS number to expect from the remote end of the session.
-                format: int32
-                maximum: 4294967295
-                minimum: 0
-                type: integer
-              peerAddress:
-                description: Address to dial when establishing the session.
-                type: string
-              peerPort:
-                description: Port to dial when establishing the session.
-                maximum: 16384
-                minimum: 0
-                type: integer
-              routerID:
-                description: BGP router ID to advertise to the peer
-                type: string
-              sourceAddress:
-                description: Source address to use when establishing the session.
-                type: string
-            required:
-            - myASN
-            - peerASN
-            - peerAddress
-            type: object
-          status:
-            description: BGPPeerStatus defines the observed state of Peer.
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .spec.peerAddress
-      name: Address
-      type: string
-    - jsonPath: .spec.peerASN
-      name: ASN
-      type: string
-    - jsonPath: .spec.bfdProfile
-      name: BFD Profile
-      type: string
-    - jsonPath: .spec.ebgpMultiHop
-      name: Multi Hops
-      type: string
-    name: v1beta2
-    schema:
-      openAPIV3Schema:
-        description: BGPPeer is the Schema for the peers API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BGPPeerSpec defines the desired state of Peer.
-            properties:
-              bfdProfile:
-                description: The name of the BFD Profile to be used for the BFD session
-                  associated to the BGP session. If not set, the BFD session won't
-                  be set up.
-                type: string
-              connectTime:
-                description: Requested BGP connect time, controls how long BGP waits
-                  between connection attempts to a neighbor.
-                type: string
-                x-kubernetes-validations:
-                - message: connect time should be between 1 seconds to 65535
-                  rule: duration(self).getSeconds() >= 1 && duration(self).getSeconds()
-                    <= 65535
-                - message: connect time should contain a whole number of seconds
-                  rule: duration(self).getMilliseconds() % 1000 == 0
-              disableMP:
-                default: false
-                description: |-
-                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
-                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
-                type: boolean
-              dualStackAddressFamily:
-                default: false
-                description: |-
-                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
-                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
-                type: boolean
-              dynamicASN:
-                description: |-
-                  DynamicASN detects the AS number to use for the remote end of the session
-                  without explicitly setting it via the ASN field. Limited to:
-                  internal - if the neighbor's ASN is different than MyASN connection is denied.
-                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
-                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
-                enum:
-                - internal
-                - external
-                type: string
-              ebgpMultiHop:
-                description: To set if the BGPPeer is multi-hops away. Needed for
-                  FRR mode only.
-                type: boolean
-              enableGracefulRestart:
-                description: |-
-                  EnableGracefulRestart allows BGP peer to continue to forward data packets
-                  along known routes while the routing protocol information is being
-                  restored. This field is immutable because it requires restart of the BGP
-                  session. Supported for FRR mode only.
-                type: boolean
-                x-kubernetes-validations:
-                - message: EnableGracefulRestart cannot be changed after creation
-                  rule: self == oldSelf
-              holdTime:
-                description: Requested BGP hold time, per RFC4271.
-                type: string
-              interface:
-                description: |-
-                  Interface is the node interface over which the unnumbered BGP peering will
-                  be established. No API validation takes place as that string value
-                  represents an interface name on the host and if user provides an invalid
-                  value, only the actual BGP session will not be established.
-                  Address and Interface are mutually exclusive and one of them must be specified.
-                type: string
-              keepaliveTime:
-                description: Requested BGP keepalive time, per RFC4271.
-                type: string
-              myASN:
-                description: AS number to use for the local end of the session.
-                format: int32
-                maximum: 4294967295
-                minimum: 0
-                type: integer
-              nodeSelectors:
-                description: |-
-                  Only connect to this peer on nodes that match one of these
-                  selectors.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.peerAddress
+          name: Address
+          type: string
+        - jsonPath: .spec.peerASN
+          name: ASN
+          type: string
+        - jsonPath: .spec.bfdProfile
+          name: BFD Profile
+          type: string
+        - jsonPath: .spec.ebgpMultiHop
+          name: Multi Hops
+          type: string
+      deprecated: true
+      deprecationWarning: v1beta1 is deprecated, please use v1beta2
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BGPPeer is the Schema for the peers API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPPeerSpec defines the desired state of Peer.
+              properties:
+                bfdProfile:
+                  type: string
+                ebgpMultiHop:
+                  description: EBGP peer is multi-hops away
+                  type: boolean
+                holdTime:
+                  description: Requested BGP hold time, per RFC4271.
+                  type: string
+                keepaliveTime:
+                  description: Requested BGP keepalive time, per RFC4271.
+                  type: string
+                myASN:
+                  description: AS number to use for the local end of the session.
+                  format: int32
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                nodeSelectors:
                   description: |-
-                    A label selector is a label query over a set of resources. The result of matchLabels and
-                    matchExpressions are ANDed. An empty label selector matches all objects. A null
-                    label selector matches no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
+                    Only connect to this peer on nodes that match one of these
+                    selectors.
+                  items:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
                               type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                        - key
-                        - operator
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          required:
+                            - key
+                            - operator
+                            - values
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
                         type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
+                    type: object
+                  type: array
+                password:
+                  description:
+                    Authentication password for routers enforcing TCP MD5
+                    authenticated sessions
+                  type: string
+                peerASN:
+                  description: AS number to expect from the remote end of the session.
+                  format: int32
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                peerAddress:
+                  description: Address to dial when establishing the session.
+                  type: string
+                peerPort:
+                  description: Port to dial when establishing the session.
+                  maximum: 16384
+                  minimum: 0
+                  type: integer
+                routerID:
+                  description: BGP router ID to advertise to the peer
+                  type: string
+                sourceAddress:
+                  description: Source address to use when establishing the session.
+                  type: string
+              required:
+                - myASN
+                - peerASN
+                - peerAddress
+              type: object
+            status:
+              description: BGPPeerStatus defines the observed state of Peer.
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.peerAddress
+          name: Address
+          type: string
+        - jsonPath: .spec.peerASN
+          name: ASN
+          type: string
+        - jsonPath: .spec.bfdProfile
+          name: BFD Profile
+          type: string
+        - jsonPath: .spec.ebgpMultiHop
+          name: Multi Hops
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BGPPeer is the Schema for the peers API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPPeerSpec defines the desired state of Peer.
+              properties:
+                bfdProfile:
+                  description:
+                    The name of the BFD Profile to be used for the BFD session
+                    associated to the BGP session. If not set, the BFD session won't
+                    be set up.
+                  type: string
+                connectTime:
+                  description:
+                    Requested BGP connect time, controls how long BGP waits
+                    between connection attempts to a neighbor.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: connect time should be between 1 seconds to 65535
+                      rule:
+                        duration(self).getSeconds() >= 1 && duration(self).getSeconds()
+                        <= 65535
+                    - message: connect time should contain a whole number of seconds
+                      rule: duration(self).getMilliseconds() % 1000 == 0
+                disableMP:
+                  default: false
+                  description: |-
+                    To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                    Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                  type: boolean
+                dualStackAddressFamily:
+                  default: false
+                  description: |-
+                    To set if we want to enable the neighbor not only for the ipfamily related to its session,
+                    but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
+                  type: boolean
+                dynamicASN:
+                  description: |-
+                    DynamicASN detects the AS number to use for the remote end of the session
+                    without explicitly setting it via the ASN field. Limited to:
+                    internal - if the neighbor's ASN is different than MyASN connection is denied.
+                    external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                  enum:
+                    - internal
+                    - external
+                  type: string
+                ebgpMultiHop:
+                  description:
+                    To set if the BGPPeer is multi-hops away. Needed for
+                    FRR mode only.
+                  type: boolean
+                enableGracefulRestart:
+                  description: |-
+                    EnableGracefulRestart allows BGP peer to continue to forward data packets
+                    along known routes while the routing protocol information is being
+                    restored. This field is immutable because it requires restart of the BGP
+                    session. Supported for FRR mode only.
+                  type: boolean
+                  x-kubernetes-validations:
+                    - message: EnableGracefulRestart cannot be changed after creation
+                      rule: self == oldSelf
+                holdTime:
+                  description: Requested BGP hold time, per RFC4271.
+                  type: string
+                interface:
+                  description: |-
+                    Interface is the node interface over which the unnumbered BGP peering will
+                    be established. No API validation takes place as that string value
+                    represents an interface name on the host and if user provides an invalid
+                    value, only the actual BGP session will not be established.
+                    Address and Interface are mutually exclusive and one of them must be specified.
+                  type: string
+                keepaliveTime:
+                  description: Requested BGP keepalive time, per RFC4271.
+                  type: string
+                myASN:
+                  description: AS number to use for the local end of the session.
+                  format: int32
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                nodeSelectors:
+                  description: |-
+                    Only connect to this peer on nodes that match one of these
+                    selectors.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description:
+                          matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description:
+                                key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                password:
+                  description:
+                    Authentication password for routers enforcing TCP MD5
+                    authenticated sessions
+                  type: string
+                passwordSecret:
+                  description: |-
+                    passwordSecret is name of the authentication secret for BGP Peer.
+                    the secret must be of type "kubernetes.io/basic-auth", and created in the
+                    same namespace as the MetalLB deployment. The password is stored in the
+                    secret as the key "password".
+                  properties:
+                    name:
+                      description:
+                        name is unique within a namespace to reference a
+                        secret resource.
+                      type: string
+                    namespace:
+                      description:
+                        namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
-                type: array
-              password:
-                description: Authentication password for routers enforcing TCP MD5
-                  authenticated sessions
-                type: string
-              passwordSecret:
-                description: |-
-                  passwordSecret is name of the authentication secret for BGP Peer.
-                  the secret must be of type "kubernetes.io/basic-auth", and created in the
-                  same namespace as the MetalLB deployment. The password is stored in the
-                  secret as the key "password".
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              peerASN:
-                description: |-
-                  AS number to expect from the remote end of the session.
-                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
-                format: int32
-                maximum: 4294967295
-                minimum: 0
-                type: integer
-              peerAddress:
-                description: Address to dial when establishing the session.
-                type: string
-              peerPort:
-                default: 179
-                description: Port to dial when establishing the session.
-                maximum: 16384
-                minimum: 1
-                type: integer
-              routerID:
-                description: BGP router ID to advertise to the peer
-                type: string
-              sourceAddress:
-                description: Source address to use when establishing the session.
-                type: string
-              vrf:
-                description: |-
-                  To set if we want to peer with the BGPPeer using an interface belonging to
-                  a host vrf
-                type: string
-            required:
-            - myASN
-            type: object
-          status:
-            description: BGPPeerStatus defines the observed state of Peer.
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                peerASN:
+                  description: |-
+                    AS number to expect from the remote end of the session.
+                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                  format: int32
+                  maximum: 4294967295
+                  minimum: 0
+                  type: integer
+                peerAddress:
+                  description: Address to dial when establishing the session.
+                  type: string
+                peerPort:
+                  default: 179
+                  description: Port to dial when establishing the session.
+                  maximum: 16384
+                  minimum: 1
+                  type: integer
+                routerID:
+                  description: BGP router ID to advertise to the peer
+                  type: string
+                sourceAddress:
+                  description: Source address to use when establishing the session.
+                  type: string
+                vrf:
+                  description: |-
+                    To set if we want to peer with the BGPPeer using an interface belonging to
+                    a host vrf
+                  type: string
+              required:
+                - myASN
+              type: object
+            status:
+              description: BGPPeerStatus defines the observed state of Peer.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -728,55 +746,55 @@ spec:
     singular: community
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          Community is a collection of aliases for communities.
-          Users can define named aliases to be used in the BGPPeer CRD.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: CommunitySpec defines the desired state of Community.
-            properties:
-              communities:
-                items:
-                  properties:
-                    name:
-                      description: The name of the alias for the community.
-                      type: string
-                    value:
-                      description: |-
-                        The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
-                        or a large community of the form large:1234:1234:1234.
-                      type: string
-                  type: object
-                type: array
-            type: object
-          status:
-            description: CommunityStatus defines the observed state of Community.
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Community is a collection of aliases for communities.
+            Users can define named aliases to be used in the BGPPeer CRD.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CommunitySpec defines the desired state of Community.
+              properties:
+                communities:
+                  items:
+                    properties:
+                      name:
+                        description: The name of the alias for the community.
+                        type: string
+                      value:
+                        description: |-
+                          The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
+                          or a large community of the form large:1234:1234:1234.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: CommunityStatus defines the observed state of Community.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -793,124 +811,126 @@ spec:
     singular: configurationstate
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.result
-      name: Result
-      type: string
-    - jsonPath: .status.errorSummary
-      name: ErrorSummary
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          ConfigurationState is a status-only CRD that reports configuration validation results from MetalLB components.
-          Labels:
-            - metallb.io/component-type: "controller" or "speaker"
-            - metallb.io/node-name: node name (only for speaker)
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          status:
-            description: ConfigurationStateStatus defines the observed state of ConfigurationState.
-            properties:
-              conditions:
-                description: Conditions contains the status conditions from the reconcilers
-                  running in this component.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              errorSummary:
-                description: |-
-                  ErrorSummary contains the aggregated error messages from reconciliation failures.
-                  This field is empty when Result is "Valid".
-                type: string
-              result:
-                description: Result indicates the configuration validation result.
-                enum:
-                - Valid
-                - Invalid
-                - Unknown
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.result
+          name: Result
+          type: string
+        - jsonPath: .status.errorSummary
+          name: ErrorSummary
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ConfigurationState is a status-only CRD that reports configuration validation results from MetalLB components.
+            Labels:
+              - metallb.io/component-type: "controller" or "speaker"
+              - metallb.io/node-name: node name (only for speaker)
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            status:
+              description: ConfigurationStateStatus defines the observed state of ConfigurationState.
+              properties:
+                conditions:
+                  description:
+                    Conditions contains the status conditions from the reconcilers
+                    running in this component.
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                errorSummary:
+                  description: |-
+                    ErrorSummary contains the aggregated error messages from reconciliation failures.
+                    This field is empty when Result is "Valid".
+                  type: string
+                result:
+                  description: Result indicates the configuration validation result.
+                  enum:
+                    - Valid
+                    - Invalid
+                    - Unknown
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -927,228 +947,234 @@ spec:
     singular: ipaddresspool
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.autoAssign
-      name: Auto Assign
-      type: boolean
-    - jsonPath: .spec.avoidBuggyIPs
-      name: Avoid Buggy IPs
-      type: boolean
-    - jsonPath: .spec.addresses
-      name: Addresses
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          IPAddressPool represents a pool of IP addresses that can be allocated
-          to LoadBalancer services.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPAddressPoolSpec defines the desired state of IPAddressPool.
-            properties:
-              addresses:
-                description: |-
-                  A list of IP address ranges over which MetalLB has authority.
-                  You can list multiple ranges in a single pool, they will all share the
-                  same settings. Each range can be either a CIDR prefix, or an explicit
-                  start-end range of IPs.
-                items:
-                  type: string
-                type: array
-              autoAssign:
-                default: true
-                description: |-
-                  AutoAssign flag used to prevent MetallB from automatic allocation
-                  for a pool.
-                type: boolean
-              avoidBuggyIPs:
-                default: false
-                description: |-
-                  AvoidBuggyIPs prevents addresses ending with .0 and .255
-                  to be used by a pool.
-                type: boolean
-              serviceAllocation:
-                description: |-
-                  AllocateTo makes ip pool allocation to specific namespace and/or service.
-                  The controller will use the pool with lowest value of priority in case of
-                  multiple matches. A pool with no priority set will be used only if the
-                  pools with priority can't be used. If multiple matching IPAddressPools are
-                  available it will check for the availability of IPs sorting the matching
-                  IPAddressPools by priority, starting from the highest to the lowest. If
-                  multiple IPAddressPools have the same priority, choice will be random.
-                properties:
-                  namespaceSelectors:
-                    description: |-
-                      NamespaceSelectors list of label selectors to select namespace(s) for ip pool,
-                      an alternative to using namespace list.
-                    items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.autoAssign
+          name: Auto Assign
+          type: boolean
+        - jsonPath: .spec.avoidBuggyIPs
+          name: Avoid Buggy IPs
+          type: boolean
+        - jsonPath: .spec.addresses
+          name: Addresses
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            IPAddressPool represents a pool of IP addresses that can be allocated
+            to LoadBalancer services.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPAddressPoolSpec defines the desired state of IPAddressPool.
+              properties:
+                addresses:
+                  description: |-
+                    A list of IP address ranges over which MetalLB has authority.
+                    You can list multiple ranges in a single pool, they will all share the
+                    same settings. Each range can be either a CIDR prefix, or an explicit
+                    start-end range of IPs.
+                  items:
+                    type: string
+                  type: array
+                autoAssign:
+                  default: true
+                  description: |-
+                    AutoAssign flag used to prevent MetallB from automatic allocation
+                    for a pool.
+                  type: boolean
+                avoidBuggyIPs:
+                  default: false
+                  description: |-
+                    AvoidBuggyIPs prevents addresses ending with .0 and .255
+                    to be used by a pool.
+                  type: boolean
+                serviceAllocation:
+                  description: |-
+                    AllocateTo makes ip pool allocation to specific namespace and/or service.
+                    The controller will use the pool with lowest value of priority in case of
+                    multiple matches. A pool with no priority set will be used only if the
+                    pools with priority can't be used. If multiple matching IPAddressPools are
+                    available it will check for the availability of IPs sorting the matching
+                    IPAddressPools by priority, starting from the highest to the lowest. If
+                    multiple IPAddressPools have the same priority, choice will be random.
+                  properties:
+                    namespaceSelectors:
                       description: |-
-                        A label selector is a label query over a set of resources. The result of matchLabels and
-                        matchExpressions are ANDed. An empty label selector matches all objects. A null
-                        label selector matches no objects.
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
-                            properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
-                                items:
+                        NamespaceSelectors list of label selectors to select namespace(s) for ip pool,
+                        an alternative to using namespace list.
+                      items:
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description:
+                              matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description:
+                                    key is the label key that the selector
+                                    applies to.
                                   type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            required:
-                            - key
-                            - operator
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    type: array
-                  namespaces:
-                    description: Namespaces list of namespace(s) on which ip pool
-                      can be attached.
-                    items:
-                      type: string
-                    type: array
-                  priority:
-                    description: Priority priority given for ip pool while ip allocation
-                      on a service.
-                    type: integer
-                  serviceSelectors:
-                    description: |-
-                      ServiceSelectors list of label selector to select service(s) for which ip pool
-                      can be used for ip allocation.
-                    items:
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    namespaces:
+                      description:
+                        Namespaces list of namespace(s) on which ip pool
+                        can be attached.
+                      items:
+                        type: string
+                      type: array
+                    priority:
+                      description:
+                        Priority priority given for ip pool while ip allocation
+                        on a service.
+                      type: integer
+                    serviceSelectors:
                       description: |-
-                        A label selector is a label query over a set of resources. The result of matchLabels and
-                        matchExpressions are ANDed. An empty label selector matches all objects. A null
-                        label selector matches no objects.
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
-                            properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
-                                items:
+                        ServiceSelectors list of label selector to select service(s) for which ip pool
+                        can be used for ip allocation.
+                      items:
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description:
+                              matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description:
+                                    key is the label key that the selector
+                                    applies to.
                                   type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            required:
-                            - key
-                            - operator
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    type: array
-                type: object
-            required:
-            - addresses
-            type: object
-          status:
-            description: IPAddressPoolStatus defines the observed state of IPAddressPool.
-            properties:
-              assignedIPv4:
-                description: AssignedIPv4 is the number of assigned IPv4 addresses.
-                format: int64
-                type: integer
-              assignedIPv6:
-                description: AssignedIPv6 is the number of assigned IPv6 addresses.
-                format: int64
-                type: integer
-              availableIPv4:
-                description: AvailableIPv4 is the number of available IPv4 addresses.
-                format: int64
-                type: integer
-              availableIPv6:
-                description: AvailableIPv6 is the number of available IPv6 addresses.
-                format: int64
-                type: integer
-            required:
-            - assignedIPv4
-            - assignedIPv6
-            - availableIPv4
-            - availableIPv6
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                  type: object
+              required:
+                - addresses
+              type: object
+            status:
+              description: IPAddressPoolStatus defines the observed state of IPAddressPool.
+              properties:
+                assignedIPv4:
+                  description: AssignedIPv4 is the number of assigned IPv4 addresses.
+                  format: int64
+                  type: integer
+                assignedIPv6:
+                  description: AssignedIPv6 is the number of assigned IPv6 addresses.
+                  format: int64
+                  type: integer
+                availableIPv4:
+                  description: AvailableIPv4 is the number of available IPv4 addresses.
+                  format: int64
+                  type: integer
+                availableIPv6:
+                  description: AvailableIPv6 is the number of available IPv6 addresses.
+                  format: int64
+                  type: integer
+              required:
+                - assignedIPv4
+                - assignedIPv6
+                - availableIPv4
+                - availableIPv6
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1165,177 +1191,183 @@ spec:
     singular: l2advertisement
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.ipAddressPools
-      name: IPAddressPools
-      type: string
-    - jsonPath: .spec.ipAddressPoolSelectors
-      name: IPAddressPool Selectors
-      type: string
-    - jsonPath: .spec.interfaces
-      name: Interfaces
-      type: string
-    - jsonPath: .spec.nodeSelectors
-      name: Node Selectors
-      priority: 10
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          L2Advertisement allows to advertise the LoadBalancer IPs provided
-          by the selected pools via L2.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: L2AdvertisementSpec defines the desired state of L2Advertisement.
-            properties:
-              interfaces:
-                description: |-
-                  A list of interfaces to announce from. The LB IP will be announced only from these interfaces.
-                  If the field is not set, we advertise from all the interfaces on the host.
-                items:
-                  type: string
-                type: array
-              ipAddressPoolSelectors:
-                description: |-
-                  A selector for the IPAddressPools which would get advertised via this advertisement.
-                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.ipAddressPools
+          name: IPAddressPools
+          type: string
+        - jsonPath: .spec.ipAddressPoolSelectors
+          name: IPAddressPool Selectors
+          type: string
+        - jsonPath: .spec.interfaces
+          name: Interfaces
+          type: string
+        - jsonPath: .spec.nodeSelectors
+          name: Node Selectors
+          priority: 10
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            L2Advertisement allows to advertise the LoadBalancer IPs provided
+            by the selected pools via L2.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: L2AdvertisementSpec defines the desired state of L2Advertisement.
+              properties:
+                interfaces:
                   description: |-
-                    A label selector is a label query over a set of resources. The result of matchLabels and
-                    matchExpressions are ANDed. An empty label selector matches all objects. A null
-                    label selector matches no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
-              ipAddressPools:
-                description: The list of IPAddressPools to advertise via this advertisement,
-                  selected by name.
-                items:
-                  type: string
-                type: array
-              nodeSelectors:
-                description: NodeSelectors allows to limit the nodes to announce as
-                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
-                  announced as next hops.
-                items:
+                    A list of interfaces to announce from. The LB IP will be announced only from these interfaces.
+                    If the field is not set, we advertise from all the interfaces on the host.
+                  items:
+                    type: string
+                  type: array
+                ipAddressPoolSelectors:
                   description: |-
-                    A label selector is a label query over a set of resources. The result of matchLabels and
-                    matchExpressions are ANDed. An empty label selector matches all objects. A null
-                    label selector matches no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
+                    A selector for the IPAddressPools which would get advertised via this advertisement.
+                    If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description:
+                          matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description:
+                                key is the label key that the selector applies
+                                to.
                               type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                        - key
-                        - operator
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
-            type: object
-          status:
-            description: L2AdvertisementStatus defines the observed state of L2Advertisement.
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                ipAddressPools:
+                  description:
+                    The list of IPAddressPools to advertise via this advertisement,
+                    selected by name.
+                  items:
+                    type: string
+                  type: array
+                nodeSelectors:
+                  description:
+                    NodeSelectors allows to limit the nodes to announce as
+                    next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                    announced as next hops.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description:
+                          matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description:
+                                key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+              type: object
+            status:
+              description: L2AdvertisementStatus defines the observed state of L2Advertisement.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1352,76 +1384,77 @@ spec:
     singular: servicebgpstatus
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.node
-      name: Node
-      type: string
-    - jsonPath: .status.serviceName
-      name: Service Name
-      type: string
-    - jsonPath: .status.serviceNamespace
-      name: Service Namespace
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ServiceBGPStatus exposes the BGP peers a service is configured
-          to be advertised to, per relevant node.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ServiceBGPStatusSpec defines the desired state of ServiceBGPStatus.
-            type: object
-          status:
-            description: MetalLBServiceBGPStatus defines the observed state of ServiceBGPStatus.
-            properties:
-              node:
-                description: Node indicates the node announcing the service.
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-              peers:
-                description: |-
-                  Peers indicate the BGP peers for which the service is configured to be advertised to.
-                  The service being actually advertised to a given peer depends on the session state and is not indicated here.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .status.node
+          name: Node
+          type: string
+        - jsonPath: .status.serviceName
+          name: Service Name
+          type: string
+        - jsonPath: .status.serviceNamespace
+          name: Service Namespace
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description:
+            ServiceBGPStatus exposes the BGP peers a service is configured
+            to be advertised to, per relevant node.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ServiceBGPStatusSpec defines the desired state of ServiceBGPStatus.
+              type: object
+            status:
+              description: MetalLBServiceBGPStatus defines the observed state of ServiceBGPStatus.
+              properties:
+                node:
+                  description: Node indicates the node announcing the service.
                   type: string
-                type: array
-              serviceName:
-                description: ServiceName indicates the service this status represents.
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-              serviceNamespace:
-                description: ServiceNamespace indicates the namespace of the service.
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                peers:
+                  description: |-
+                    Peers indicate the BGP peers for which the service is configured to be advertised to.
+                    The service being actually advertised to a given peer depends on the session state and is not indicated here.
+                  items:
+                    type: string
+                  type: array
+                serviceName:
+                  description: ServiceName indicates the service this status represents.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                serviceNamespace:
+                  description: ServiceNamespace indicates the namespace of the service.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1438,77 +1471,79 @@ spec:
     singular: servicel2status
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.node
-      name: Allocated Node
-      type: string
-    - jsonPath: .status.serviceName
-      name: Service Name
-      type: string
-    - jsonPath: .status.serviceNamespace
-      name: Service Namespace
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ServiceL2Status reveals the actual traffic status of loadbalancer
-          services in layer2 mode.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ServiceL2StatusSpec defines the desired state of ServiceL2Status.
-            type: object
-          status:
-            description: MetalLBServiceL2Status defines the observed state of ServiceL2Status.
-            properties:
-              interfaces:
-                description: Interfaces indicates the interfaces that receive the
-                  directed traffic
-                items:
-                  description: InterfaceInfo defines interface info of layer2 announcement.
-                  properties:
-                    name:
-                      description: Name the name of network interface card
-                      type: string
-                  type: object
-                type: array
-              node:
-                description: Node indicates the node that receives the directed traffic
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-              serviceName:
-                description: ServiceName indicates the service this status represents
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-              serviceNamespace:
-                description: ServiceNamespace indicates the namespace of the service
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.node
+          name: Allocated Node
+          type: string
+        - jsonPath: .status.serviceName
+          name: Service Name
+          type: string
+        - jsonPath: .status.serviceNamespace
+          name: Service Namespace
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description:
+            ServiceL2Status reveals the actual traffic status of loadbalancer
+            services in layer2 mode.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ServiceL2StatusSpec defines the desired state of ServiceL2Status.
+              type: object
+            status:
+              description: MetalLBServiceL2Status defines the observed state of ServiceL2Status.
+              properties:
+                interfaces:
+                  description:
+                    Interfaces indicates the interfaces that receive the
+                    directed traffic
+                  items:
+                    description: InterfaceInfo defines interface info of layer2 announcement.
+                    properties:
+                      name:
+                        description: Name the name of network interface card
+                        type: string
+                    type: object
+                  type: array
+                node:
+                  description: Node indicates the node that receives the directed traffic
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                serviceName:
+                  description: ServiceName indicates the service this status represents
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                serviceNamespace:
+                  description: ServiceNamespace indicates the namespace of the service
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/addons/metallb/crd.yaml
+++ b/addons/metallb/crd.yaml
@@ -1,10 +1,10 @@
-# Sourced from: https://raw.githubusercontent.com/metallb/metallb/v0.15.2/config/manifests/metallb-native.yaml
+# Sourced from: https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml
 # This file only contains the CRDs.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: bfdprofiles.metallb.io
 spec:
   group: metallb.io
@@ -15,117 +15,117 @@ spec:
     singular: bfdprofile
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.passiveMode
-          name: Passive Mode
-          type: boolean
-        - jsonPath: .spec.transmitInterval
-          name: Transmit Interval
-          type: integer
-        - jsonPath: .spec.receiveInterval
-          name: Receive Interval
-          type: integer
-        - jsonPath: .spec.detectMultiplier
-          name: Multiplier
-          type: integer
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            BFDProfile represents the settings of the bfd session that can be
-            optionally associated with a BGP session.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BFDProfileSpec defines the desired state of BFDProfile.
-              properties:
-                detectMultiplier:
-                  description: |-
-                    Configures the detection multiplier to determine
-                    packet loss. The remote transmission interval will be multiplied
-                    by this value to determine the connection loss detection timer.
-                  format: int32
-                  maximum: 255
-                  minimum: 2
-                  type: integer
-                echoInterval:
-                  description: |-
-                    Configures the minimal echo receive transmission
-                    interval that this system is capable of handling in milliseconds.
-                    Defaults to 50ms
-                  format: int32
-                  maximum: 60000
-                  minimum: 10
-                  type: integer
-                echoMode:
-                  description: |-
-                    Enables or disables the echo transmission mode.
-                    This mode is disabled by default, and not supported on multi
-                    hops setups.
-                  type: boolean
-                minimumTtl:
-                  description: |-
-                    For multi hop sessions only: configure the minimum
-                    expected TTL for an incoming BFD control packet.
-                  format: int32
-                  maximum: 254
-                  minimum: 1
-                  type: integer
-                passiveMode:
-                  description: |-
-                    Mark session as passive: a passive session will not
-                    attempt to start the connection and will wait for control packets
-                    from peer before it begins replying.
-                  type: boolean
-                receiveInterval:
-                  description: |-
-                    The minimum interval that this system is capable of
-                    receiving control packets in milliseconds.
-                    Defaults to 300ms.
-                  format: int32
-                  maximum: 60000
-                  minimum: 10
-                  type: integer
-                transmitInterval:
-                  description: |-
-                    The minimum transmission interval (less jitter)
-                    that this system wants to use to send BFD control packets in
-                    milliseconds. Defaults to 300ms
-                  format: int32
-                  maximum: 60000
-                  minimum: 10
-                  type: integer
-              type: object
-            status:
-              description: BFDProfileStatus defines the observed state of BFDProfile.
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.passiveMode
+      name: Passive Mode
+      type: boolean
+    - jsonPath: .spec.transmitInterval
+      name: Transmit Interval
+      type: integer
+    - jsonPath: .spec.receiveInterval
+      name: Receive Interval
+      type: integer
+    - jsonPath: .spec.detectMultiplier
+      name: Multiplier
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BFDProfile represents the settings of the bfd session that can be
+          optionally associated with a BGP session.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BFDProfileSpec defines the desired state of BFDProfile.
+            properties:
+              detectMultiplier:
+                description: |-
+                  Configures the detection multiplier to determine
+                  packet loss. The remote transmission interval will be multiplied
+                  by this value to determine the connection loss detection timer.
+                format: int32
+                maximum: 255
+                minimum: 2
+                type: integer
+              echoInterval:
+                description: |-
+                  Configures the minimal echo receive transmission
+                  interval that this system is capable of handling in milliseconds.
+                  Defaults to 50ms
+                format: int32
+                maximum: 60000
+                minimum: 10
+                type: integer
+              echoMode:
+                description: |-
+                  Enables or disables the echo transmission mode.
+                  This mode is disabled by default, and not supported on multi
+                  hops setups.
+                type: boolean
+              minimumTtl:
+                description: |-
+                  For multi hop sessions only: configure the minimum
+                  expected TTL for an incoming BFD control packet.
+                format: int32
+                maximum: 254
+                minimum: 1
+                type: integer
+              passiveMode:
+                description: |-
+                  Mark session as passive: a passive session will not
+                  attempt to start the connection and will wait for control packets
+                  from peer before it begins replying.
+                type: boolean
+              receiveInterval:
+                description: |-
+                  The minimum interval that this system is capable of
+                  receiving control packets in milliseconds.
+                  Defaults to 300ms.
+                format: int32
+                maximum: 60000
+                minimum: 10
+                type: integer
+              transmitInterval:
+                description: |-
+                  The minimum transmission interval (less jitter)
+                  that this system wants to use to send BFD control packets in
+                  milliseconds. Defaults to 300ms
+                format: int32
+                maximum: 60000
+                minimum: 10
+                type: integer
+            type: object
+          status:
+            description: BFDProfileStatus defines the observed state of BFDProfile.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: bgpadvertisements.metallb.io
 spec:
   group: metallb.io
@@ -136,221 +136,213 @@ spec:
     singular: bgpadvertisement
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.ipAddressPools
-          name: IPAddressPools
-          type: string
-        - jsonPath: .spec.ipAddressPoolSelectors
-          name: IPAddressPool Selectors
-          type: string
-        - jsonPath: .spec.peers
-          name: Peers
-          type: string
-        - jsonPath: .spec.nodeSelectors
-          name: Node Selectors
-          priority: 10
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            BGPAdvertisement allows to advertise the IPs coming
-            from the selected IPAddressPools via BGP, setting the parameters of the
-            BGP Advertisement.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPAdvertisementSpec defines the desired state of BGPAdvertisement.
-              properties:
-                aggregationLength:
-                  default: 32
-                  description:
-                    The aggregation-length advertisement option lets you
-                    “roll up” the /32s into a larger prefix. Defaults to 32. Works for
-                    IPv4 addresses.
-                  format: int32
-                  minimum: 1
-                  type: integer
-                aggregationLengthV6:
-                  default: 128
-                  description:
-                    The aggregation-length advertisement option lets you
-                    “roll up” the /128s into a larger prefix. Defaults to 128. Works
-                    for IPv6 addresses.
-                  format: int32
-                  type: integer
-                communities:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.peers
+      name: Peers
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BGPAdvertisement allows to advertise the IPs coming
+          from the selected IPAddressPools via BGP, setting the parameters of the
+          BGP Advertisement.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPAdvertisementSpec defines the desired state of BGPAdvertisement.
+            properties:
+              aggregationLength:
+                default: 32
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                  IPv4 addresses.
+                format: int32
+                minimum: 1
+                type: integer
+              aggregationLengthV6:
+                default: 128
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                  for IPv6 addresses.
+                format: int32
+                type: integer
+              communities:
+                description: |-
+                  The BGP communities to be associated with the announcement. Each item can be a standard community of the
+                  form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
+                  Community CRD.
+                items:
+                  type: string
+                type: array
+              ipAddressPoolSelectors:
+                description: |-
+                  A selector for the IPAddressPools which would get advertised via this advertisement.
+                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
+                items:
                   description: |-
-                    The BGP communities to be associated with the announcement. Each item can be a standard community of the
-                    form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
-                    Community CRD.
-                  items:
-                    type: string
-                  type: array
-                ipAddressPoolSelectors:
-                  description: |-
-                    A selector for the IPAddressPools which would get advertised via this advertisement.
-                    If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
-                  items:
-                    description: |-
-                      A label selector is a label query over a set of resources. The result of matchLabels and
-                      matchExpressions are ANDed. An empty label selector matches all objects. A null
-                      label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description:
-                          matchExpressions is a list of label selector requirements.
-                          The requirements are ANDed.
-                        items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
-                          properties:
-                            key:
-                              description:
-                                key is the label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
                         description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
                         type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                ipAddressPools:
-                  description:
-                    The list of IPAddressPools to advertise via this advertisement,
-                    selected by name.
-                  items:
-                    type: string
-                  type: array
-                localPref:
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              ipAddressPools:
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
+                items:
+                  type: string
+                type: array
+              localPref:
+                description: |-
+                  The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
+                  Path with higher localpref is preferred over one with lower localpref.
+                format: int32
+                type: integer
+              nodeSelectors:
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
+                items:
                   description: |-
-                    The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
-                    Path with higher localpref is preferred over one with lower localpref.
-                  format: int32
-                  type: integer
-                nodeSelectors:
-                  description:
-                    NodeSelectors allows to limit the nodes to announce as
-                    next hops for the LoadBalancer IP. When empty, all the nodes having  are
-                    announced as next hops.
-                  items:
-                    description: |-
-                      A label selector is a label query over a set of resources. The result of matchLabels and
-                      matchExpressions are ANDed. An empty label selector matches all objects. A null
-                      label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description:
-                          matchExpressions is a list of label selector requirements.
-                          The requirements are ANDed.
-                        items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
-                          properties:
-                            key:
-                              description:
-                                key is the label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
                         description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
                         type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                peers:
-                  description: |-
-                    Peers limits the bgppeer to advertise the ips of the selected pools to.
-                    When empty, the loadbalancer IP is announced to all the BGPPeers configured.
-                  items:
-                    type: string
-                  type: array
-              type: object
-            status:
-              description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              peers:
+                description: |-
+                  Peers limits the bgppeer to advertise the ips of the selected pools to.
+                  When empty, the loadbalancer IP is announced to all the BGPPeers configured.
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: bgppeers.metallb.io
 spec:
   conversion:
@@ -362,8 +354,8 @@ spec:
           namespace: metallb-system
           path: /convert
       conversionReviewVersions:
-        - v1beta1
-        - v1beta2
+      - v1beta1
+      - v1beta2
   group: metallb.io
   names:
     kind: BGPPeer
@@ -372,370 +364,360 @@ spec:
     singular: bgppeer
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.peerAddress
-          name: Address
-          type: string
-        - jsonPath: .spec.peerASN
-          name: ASN
-          type: string
-        - jsonPath: .spec.bfdProfile
-          name: BFD Profile
-          type: string
-        - jsonPath: .spec.ebgpMultiHop
-          name: Multi Hops
-          type: string
-      deprecated: true
-      deprecationWarning: v1beta1 is deprecated, please use v1beta2
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: BGPPeer is the Schema for the peers API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPPeerSpec defines the desired state of Peer.
-              properties:
-                bfdProfile:
-                  type: string
-                ebgpMultiHop:
-                  description: EBGP peer is multi-hops away
-                  type: boolean
-                holdTime:
-                  description: Requested BGP hold time, per RFC4271.
-                  type: string
-                keepaliveTime:
-                  description: Requested BGP keepalive time, per RFC4271.
-                  type: string
-                myASN:
-                  description: AS number to use for the local end of the session.
-                  format: int32
-                  maximum: 4294967295
-                  minimum: 0
-                  type: integer
-                nodeSelectors:
-                  description: |-
-                    Only connect to this peer on nodes that match one of these
-                    selectors.
-                  items:
-                    properties:
-                      matchExpressions:
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-                              minItems: 1
-                              type: array
-                          required:
-                            - key
-                            - operator
-                            - values
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  type: array
-                password:
-                  description:
-                    Authentication password for routers enforcing TCP MD5
-                    authenticated sessions
-                  type: string
-                peerASN:
-                  description: AS number to expect from the remote end of the session.
-                  format: int32
-                  maximum: 4294967295
-                  minimum: 0
-                  type: integer
-                peerAddress:
-                  description: Address to dial when establishing the session.
-                  type: string
-                peerPort:
-                  description: Port to dial when establishing the session.
-                  maximum: 16384
-                  minimum: 0
-                  type: integer
-                routerID:
-                  description: BGP router ID to advertise to the peer
-                  type: string
-                sourceAddress:
-                  description: Source address to use when establishing the session.
-                  type: string
-              required:
-                - myASN
-                - peerASN
-                - peerAddress
-              type: object
-            status:
-              description: BGPPeerStatus defines the observed state of Peer.
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.peerAddress
-          name: Address
-          type: string
-        - jsonPath: .spec.peerASN
-          name: ASN
-          type: string
-        - jsonPath: .spec.bfdProfile
-          name: BFD Profile
-          type: string
-        - jsonPath: .spec.ebgpMultiHop
-          name: Multi Hops
-          type: string
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: BGPPeer is the Schema for the peers API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BGPPeerSpec defines the desired state of Peer.
-              properties:
-                bfdProfile:
-                  description:
-                    The name of the BFD Profile to be used for the BFD session
-                    associated to the BGP session. If not set, the BFD session won't
-                    be set up.
-                  type: string
-                connectTime:
-                  description:
-                    Requested BGP connect time, controls how long BGP waits
-                    between connection attempts to a neighbor.
-                  type: string
-                  x-kubernetes-validations:
-                    - message: connect time should be between 1 seconds to 65535
-                      rule:
-                        duration(self).getSeconds() >= 1 && duration(self).getSeconds()
-                        <= 65535
-                    - message: connect time should contain a whole number of seconds
-                      rule: duration(self).getMilliseconds() % 1000 == 0
-                disableMP:
-                  default: false
-                  description: |-
-                    To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
-                    Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
-                  type: boolean
-                dualStackAddressFamily:
-                  default: false
-                  description: |-
-                    To set if we want to enable the neighbor not only for the ipfamily related to its session,
-                    but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
-                  type: boolean
-                dynamicASN:
-                  description: |-
-                    DynamicASN detects the AS number to use for the remote end of the session
-                    without explicitly setting it via the ASN field. Limited to:
-                    internal - if the neighbor's ASN is different than MyASN connection is denied.
-                    external - if the neighbor's ASN is the same as MyASN the connection is denied.
-                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
-                  enum:
-                    - internal
-                    - external
-                  type: string
-                ebgpMultiHop:
-                  description:
-                    To set if the BGPPeer is multi-hops away. Needed for
-                    FRR mode only.
-                  type: boolean
-                enableGracefulRestart:
-                  description: |-
-                    EnableGracefulRestart allows BGP peer to continue to forward data packets
-                    along known routes while the routing protocol information is being
-                    restored. This field is immutable because it requires restart of the BGP
-                    session. Supported for FRR mode only.
-                  type: boolean
-                  x-kubernetes-validations:
-                    - message: EnableGracefulRestart cannot be changed after creation
-                      rule: self == oldSelf
-                holdTime:
-                  description: Requested BGP hold time, per RFC4271.
-                  type: string
-                interface:
-                  description: |-
-                    Interface is the node interface over which the unnumbered BGP peering will
-                    be established. No API validation takes place as that string value
-                    represents an interface name on the host and if user provides an invalid
-                    value, only the actual BGP session will not be established.
-                    Address and Interface are mutually exclusive and one of them must be specified.
-                  type: string
-                keepaliveTime:
-                  description: Requested BGP keepalive time, per RFC4271.
-                  type: string
-                myASN:
-                  description: AS number to use for the local end of the session.
-                  format: int32
-                  maximum: 4294967295
-                  minimum: 0
-                  type: integer
-                nodeSelectors:
-                  description: |-
-                    Only connect to this peer on nodes that match one of these
-                    selectors.
-                  items:
-                    description: |-
-                      A label selector is a label query over a set of resources. The result of matchLabels and
-                      matchExpressions are ANDed. An empty label selector matches all objects. A null
-                      label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description:
-                          matchExpressions is a list of label selector requirements.
-                          The requirements are ANDed.
-                        items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
-                          properties:
-                            key:
-                              description:
-                                key is the label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                password:
-                  description:
-                    Authentication password for routers enforcing TCP MD5
-                    authenticated sessions
-                  type: string
-                passwordSecret:
-                  description: |-
-                    passwordSecret is name of the authentication secret for BGP Peer.
-                    the secret must be of type "kubernetes.io/basic-auth", and created in the
-                    same namespace as the MetalLB deployment. The password is stored in the
-                    secret as the key "password".
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BGPPeer is the Schema for the peers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec defines the desired state of Peer.
+            properties:
+              bfdProfile:
+                type: string
+              ebgpMultiHop:
+                description: EBGP peer is multi-hops away
+                type: boolean
+              holdTime:
+                description: Requested BGP hold time, per RFC4271.
+                type: string
+              keepaliveTime:
+                description: Requested BGP keepalive time, per RFC4271.
+                type: string
+              myASN:
+                description: AS number to use for the local end of the session.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              nodeSelectors:
+                description: |-
+                  Only connect to this peer on nodes that match one of these
+                  selectors.
+                items:
                   properties:
-                    name:
-                      description:
-                        name is unique within a namespace to reference a
-                        secret resource.
-                      type: string
-                    namespace:
-                      description:
-                        namespace defines the space within which the secret
-                        name must be unique.
-                      type: string
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            minItems: 1
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              password:
+                description: Authentication password for routers enforcing TCP MD5
+                  authenticated sessions
+                type: string
+              peerASN:
+                description: AS number to expect from the remote end of the session.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              peerAddress:
+                description: Address to dial when establishing the session.
+                type: string
+              peerPort:
+                description: Port to dial when establishing the session.
+                maximum: 16384
+                minimum: 0
+                type: integer
+              routerID:
+                description: BGP router ID to advertise to the peer
+                type: string
+              sourceAddress:
+                description: Source address to use when establishing the session.
+                type: string
+            required:
+            - myASN
+            - peerASN
+            - peerAddress
+            type: object
+          status:
+            description: BGPPeerStatus defines the observed state of Peer.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BGPPeer is the Schema for the peers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec defines the desired state of Peer.
+            properties:
+              bfdProfile:
+                description: The name of the BFD Profile to be used for the BFD session
+                  associated to the BGP session. If not set, the BFD session won't
+                  be set up.
+                type: string
+              connectTime:
+                description: Requested BGP connect time, controls how long BGP waits
+                  between connection attempts to a neighbor.
+                type: string
+                x-kubernetes-validations:
+                - message: connect time should be between 1 seconds to 65535
+                  rule: duration(self).getSeconds() >= 1 && duration(self).getSeconds()
+                    <= 65535
+                - message: connect time should contain a whole number of seconds
+                  rule: duration(self).getMilliseconds() % 1000 == 0
+              disableMP:
+                default: false
+                description: |-
+                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                type: boolean
+              dualStackAddressFamily:
+                default: false
+                description: |-
+                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
+                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
+                type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
+              ebgpMultiHop:
+                description: To set if the BGPPeer is multi-hops away. Needed for
+                  FRR mode only.
+                type: boolean
+              enableGracefulRestart:
+                description: |-
+                  EnableGracefulRestart allows BGP peer to continue to forward data packets
+                  along known routes while the routing protocol information is being
+                  restored. This field is immutable because it requires restart of the BGP
+                  session. Supported for FRR mode only.
+                type: boolean
+                x-kubernetes-validations:
+                - message: EnableGracefulRestart cannot be changed after creation
+                  rule: self == oldSelf
+              holdTime:
+                description: Requested BGP hold time, per RFC4271.
+                type: string
+              interface:
+                description: |-
+                  Interface is the node interface over which the unnumbered BGP peering will
+                  be established. No API validation takes place as that string value
+                  represents an interface name on the host and if user provides an invalid
+                  value, only the actual BGP session will not be established.
+                  Address and Interface are mutually exclusive and one of them must be specified.
+                type: string
+              keepaliveTime:
+                description: Requested BGP keepalive time, per RFC4271.
+                type: string
+              myASN:
+                description: AS number to use for the local end of the session.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              nodeSelectors:
+                description: |-
+                  Only connect to this peer on nodes that match one of these
+                  selectors.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
                   type: object
                   x-kubernetes-map-type: atomic
-                peerASN:
-                  description: |-
-                    AS number to expect from the remote end of the session.
-                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
-                  format: int32
-                  maximum: 4294967295
-                  minimum: 0
-                  type: integer
-                peerAddress:
-                  description: Address to dial when establishing the session.
-                  type: string
-                peerPort:
-                  default: 179
-                  description: Port to dial when establishing the session.
-                  maximum: 16384
-                  minimum: 1
-                  type: integer
-                routerID:
-                  description: BGP router ID to advertise to the peer
-                  type: string
-                sourceAddress:
-                  description: Source address to use when establishing the session.
-                  type: string
-                vrf:
-                  description: |-
-                    To set if we want to peer with the BGPPeer using an interface belonging to
-                    a host vrf
-                  type: string
-              required:
-                - myASN
-              type: object
-            status:
-              description: BGPPeerStatus defines the observed state of Peer.
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              password:
+                description: Authentication password for routers enforcing TCP MD5
+                  authenticated sessions
+                type: string
+              passwordSecret:
+                description: |-
+                  passwordSecret is name of the authentication secret for BGP Peer.
+                  the secret must be of type "kubernetes.io/basic-auth", and created in the
+                  same namespace as the MetalLB deployment. The password is stored in the
+                  secret as the key "password".
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              peerASN:
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              peerAddress:
+                description: Address to dial when establishing the session.
+                type: string
+              peerPort:
+                default: 179
+                description: Port to dial when establishing the session.
+                maximum: 16384
+                minimum: 1
+                type: integer
+              routerID:
+                description: BGP router ID to advertise to the peer
+                type: string
+              sourceAddress:
+                description: Source address to use when establishing the session.
+                type: string
+              vrf:
+                description: |-
+                  To set if we want to peer with the BGPPeer using an interface belonging to
+                  a host vrf
+                type: string
+            required:
+            - myASN
+            type: object
+          status:
+            description: BGPPeerStatus defines the observed state of Peer.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: communities.metallb.io
 spec:
   group: metallb.io
@@ -746,61 +728,195 @@ spec:
     singular: community
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            Community is a collection of aliases for communities.
-            Users can define named aliases to be used in the BGPPeer CRD.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: CommunitySpec defines the desired state of Community.
-              properties:
-                communities:
-                  items:
-                    properties:
-                      name:
-                        description: The name of the alias for the community.
-                        type: string
-                      value:
-                        description: |-
-                          The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
-                          or a large community of the form large:1234:1234:1234.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            status:
-              description: CommunityStatus defines the observed state of Community.
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Community is a collection of aliases for communities.
+          Users can define named aliases to be used in the BGPPeer CRD.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CommunitySpec defines the desired state of Community.
+            properties:
+              communities:
+                items:
+                  properties:
+                    name:
+                      description: The name of the alias for the community.
+                      type: string
+                    value:
+                      description: |-
+                        The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
+                        or a large community of the form large:1234:1234:1234.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: CommunityStatus defines the observed state of Community.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: configurationstates.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: ConfigurationState
+    listKind: ConfigurationStateList
+    plural: configurationstates
+    singular: configurationstate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    - jsonPath: .status.errorSummary
+      name: ErrorSummary
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ConfigurationState is a status-only CRD that reports configuration validation results from MetalLB components.
+          Labels:
+            - metallb.io/component-type: "controller" or "speaker"
+            - metallb.io/node-name: node name (only for speaker)
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            description: ConfigurationStateStatus defines the observed state of ConfigurationState.
+            properties:
+              conditions:
+                description: Conditions contains the status conditions from the reconcilers
+                  running in this component.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              errorSummary:
+                description: |-
+                  ErrorSummary contains the aggregated error messages from reconciliation failures.
+                  This field is empty when Result is "Valid".
+                type: string
+              result:
+                description: Result indicates the configuration validation result.
+                enum:
+                - Valid
+                - Invalid
+                - Unknown
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ipaddresspools.metallb.io
 spec:
   group: metallb.io
@@ -811,240 +927,234 @@ spec:
     singular: ipaddresspool
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.autoAssign
-          name: Auto Assign
-          type: boolean
-        - jsonPath: .spec.avoidBuggyIPs
-          name: Avoid Buggy IPs
-          type: boolean
-        - jsonPath: .spec.addresses
-          name: Addresses
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            IPAddressPool represents a pool of IP addresses that can be allocated
-            to LoadBalancer services.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IPAddressPoolSpec defines the desired state of IPAddressPool.
-              properties:
-                addresses:
-                  description: |-
-                    A list of IP address ranges over which MetalLB has authority.
-                    You can list multiple ranges in a single pool, they will all share the
-                    same settings. Each range can be either a CIDR prefix, or an explicit
-                    start-end range of IPs.
-                  items:
-                    type: string
-                  type: array
-                autoAssign:
-                  default: true
-                  description: |-
-                    AutoAssign flag used to prevent MetallB from automatic allocation
-                    for a pool.
-                  type: boolean
-                avoidBuggyIPs:
-                  default: false
-                  description: |-
-                    AvoidBuggyIPs prevents addresses ending with .0 and .255
-                    to be used by a pool.
-                  type: boolean
-                serviceAllocation:
-                  description: |-
-                    AllocateTo makes ip pool allocation to specific namespace and/or service.
-                    The controller will use the pool with lowest value of priority in case of
-                    multiple matches. A pool with no priority set will be used only if the
-                    pools with priority can't be used. If multiple matching IPAddressPools are
-                    available it will check for the availability of IPs sorting the matching
-                    IPAddressPools by priority, starting from the highest to the lowest. If
-                    multiple IPAddressPools have the same priority, choice will be random.
-                  properties:
-                    namespaceSelectors:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.autoAssign
+      name: Auto Assign
+      type: boolean
+    - jsonPath: .spec.avoidBuggyIPs
+      name: Avoid Buggy IPs
+      type: boolean
+    - jsonPath: .spec.addresses
+      name: Addresses
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          IPAddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressPoolSpec defines the desired state of IPAddressPool.
+            properties:
+              addresses:
+                description: |-
+                  A list of IP address ranges over which MetalLB has authority.
+                  You can list multiple ranges in a single pool, they will all share the
+                  same settings. Each range can be either a CIDR prefix, or an explicit
+                  start-end range of IPs.
+                items:
+                  type: string
+                type: array
+              autoAssign:
+                default: true
+                description: |-
+                  AutoAssign flag used to prevent MetallB from automatic allocation
+                  for a pool.
+                type: boolean
+              avoidBuggyIPs:
+                default: false
+                description: |-
+                  AvoidBuggyIPs prevents addresses ending with .0 and .255
+                  to be used by a pool.
+                type: boolean
+              serviceAllocation:
+                description: |-
+                  AllocateTo makes ip pool allocation to specific namespace and/or service.
+                  The controller will use the pool with lowest value of priority in case of
+                  multiple matches. A pool with no priority set will be used only if the
+                  pools with priority can't be used. If multiple matching IPAddressPools are
+                  available it will check for the availability of IPs sorting the matching
+                  IPAddressPools by priority, starting from the highest to the lowest. If
+                  multiple IPAddressPools have the same priority, choice will be random.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors list of label selectors to select namespace(s) for ip pool,
+                      an alternative to using namespace list.
+                    items:
                       description: |-
-                        NamespaceSelectors list of label selectors to select namespace(s) for ip pool,
-                        an alternative to using namespace list.
-                      items:
-                        description: |-
-                          A label selector is a label query over a set of resources. The result of matchLabels and
-                          matchExpressions are ANDed. An empty label selector matches all objects. A null
-                          label selector matches no objects.
-                        properties:
-                          matchExpressions:
-                            description:
-                              matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description:
-                                    key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
                             description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
                             type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      type: array
-                    namespaces:
-                      description:
-                        Namespaces list of namespace(s) on which ip pool
-                        can be attached.
-                      items:
-                        type: string
-                      type: array
-                    priority:
-                      description:
-                        Priority priority given for ip pool while ip allocation
-                        on a service.
-                      type: integer
-                    serviceSelectors:
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  namespaces:
+                    description: Namespaces list of namespace(s) on which ip pool
+                      can be attached.
+                    items:
+                      type: string
+                    type: array
+                  priority:
+                    description: Priority priority given for ip pool while ip allocation
+                      on a service.
+                    type: integer
+                  serviceSelectors:
+                    description: |-
+                      ServiceSelectors list of label selector to select service(s) for which ip pool
+                      can be used for ip allocation.
+                    items:
                       description: |-
-                        ServiceSelectors list of label selector to select service(s) for which ip pool
-                        can be used for ip allocation.
-                      items:
-                        description: |-
-                          A label selector is a label query over a set of resources. The result of matchLabels and
-                          matchExpressions are ANDed. An empty label selector matches all objects. A null
-                          label selector matches no objects.
-                        properties:
-                          matchExpressions:
-                            description:
-                              matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description:
-                                    key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
                             description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
                             type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      type: array
-                  type: object
-              required:
-                - addresses
-              type: object
-            status:
-              description: IPAddressPoolStatus defines the observed state of IPAddressPool.
-              properties:
-                assignedIPv4:
-                  description: AssignedIPv4 is the number of assigned IPv4 addresses.
-                  format: int64
-                  type: integer
-                assignedIPv6:
-                  description: AssignedIPv6 is the number of assigned IPv6 addresses.
-                  format: int64
-                  type: integer
-                availableIPv4:
-                  description: AvailableIPv4 is the number of available IPv4 addresses.
-                  format: int64
-                  type: integer
-                availableIPv6:
-                  description: AvailableIPv6 is the number of available IPv6 addresses.
-                  format: int64
-                  type: integer
-              required:
-                - assignedIPv4
-                - assignedIPv6
-                - availableIPv4
-                - availableIPv6
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+            required:
+            - addresses
+            type: object
+          status:
+            description: IPAddressPoolStatus defines the observed state of IPAddressPool.
+            properties:
+              assignedIPv4:
+                description: AssignedIPv4 is the number of assigned IPv4 addresses.
+                format: int64
+                type: integer
+              assignedIPv6:
+                description: AssignedIPv6 is the number of assigned IPv6 addresses.
+                format: int64
+                type: integer
+              availableIPv4:
+                description: AvailableIPv4 is the number of available IPv4 addresses.
+                format: int64
+                type: integer
+              availableIPv6:
+                description: AvailableIPv6 is the number of available IPv6 addresses.
+                format: int64
+                type: integer
+            required:
+            - assignedIPv4
+            - assignedIPv6
+            - availableIPv4
+            - availableIPv6
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l2advertisements.metallb.io
 spec:
   group: metallb.io
@@ -1055,189 +1165,183 @@ spec:
     singular: l2advertisement
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.ipAddressPools
-          name: IPAddressPools
-          type: string
-        - jsonPath: .spec.ipAddressPoolSelectors
-          name: IPAddressPool Selectors
-          type: string
-        - jsonPath: .spec.interfaces
-          name: Interfaces
-          type: string
-        - jsonPath: .spec.nodeSelectors
-          name: Node Selectors
-          priority: 10
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            L2Advertisement allows to advertise the LoadBalancer IPs provided
-            by the selected pools via L2.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: L2AdvertisementSpec defines the desired state of L2Advertisement.
-              properties:
-                interfaces:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.interfaces
+      name: Interfaces
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          L2Advertisement allows to advertise the LoadBalancer IPs provided
+          by the selected pools via L2.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: L2AdvertisementSpec defines the desired state of L2Advertisement.
+            properties:
+              interfaces:
+                description: |-
+                  A list of interfaces to announce from. The LB IP will be announced only from these interfaces.
+                  If the field is not set, we advertise from all the interfaces on the host.
+                items:
+                  type: string
+                type: array
+              ipAddressPoolSelectors:
+                description: |-
+                  A selector for the IPAddressPools which would get advertised via this advertisement.
+                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
+                items:
                   description: |-
-                    A list of interfaces to announce from. The LB IP will be announced only from these interfaces.
-                    If the field is not set, we advertise from all the interfaces on the host.
-                  items:
-                    type: string
-                  type: array
-                ipAddressPoolSelectors:
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              ipAddressPools:
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
+                items:
+                  type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
+                items:
                   description: |-
-                    A selector for the IPAddressPools which would get advertised via this advertisement.
-                    If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
-                  items:
-                    description: |-
-                      A label selector is a label query over a set of resources. The result of matchLabels and
-                      matchExpressions are ANDed. An empty label selector matches all objects. A null
-                      label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description:
-                          matchExpressions is a list of label selector requirements.
-                          The requirements are ANDed.
-                        items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
-                          properties:
-                            key:
-                              description:
-                                key is the label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
                         description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                ipAddressPools:
-                  description:
-                    The list of IPAddressPools to advertise via this advertisement,
-                    selected by name.
-                  items:
-                    type: string
-                  type: array
-                nodeSelectors:
-                  description:
-                    NodeSelectors allows to limit the nodes to announce as
-                    next hops for the LoadBalancer IP. When empty, all the nodes having  are
-                    announced as next hops.
-                  items:
-                    description: |-
-                      A label selector is a label query over a set of resources. The result of matchLabels and
-                      matchExpressions are ANDed. An empty label selector matches all objects. A null
-                      label selector matches no objects.
-                    properties:
-                      matchExpressions:
-                        description:
-                          matchExpressions is a list of label selector requirements.
-                          The requirements are ANDed.
-                        items:
-                          description: |-
-                            A label selector requirement is a selector that contains values, a key, and an operator that
-                            relates the key and values.
-                          properties:
-                            key:
-                              description:
-                                key is the label key that the selector applies
-                                to.
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
                               type: string
-                            operator:
-                              description: |-
-                                operator represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: |-
-                                values is an array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
                         type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-              type: object
-            status:
-              description: L2AdvertisementStatus defines the observed state of L2Advertisement.
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+            type: object
+          status:
+            description: L2AdvertisementStatus defines the observed state of L2Advertisement.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicebgpstatuses.metallb.io
 spec:
   group: metallb.io
@@ -1248,83 +1352,82 @@ spec:
     singular: servicebgpstatus
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.node
-          name: Node
-          type: string
-        - jsonPath: .status.serviceName
-          name: Service Name
-          type: string
-        - jsonPath: .status.serviceNamespace
-          name: Service Namespace
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description:
-            ServiceBGPStatus exposes the BGP peers a service is configured
-            to be advertised to, per relevant node.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ServiceBGPStatusSpec defines the desired state of ServiceBGPStatus.
-              type: object
-            status:
-              description: MetalLBServiceBGPStatus defines the observed state of ServiceBGPStatus.
-              properties:
-                node:
-                  description: Node indicates the node announcing the service.
+  - additionalPrinterColumns:
+    - jsonPath: .status.node
+      name: Node
+      type: string
+    - jsonPath: .status.serviceName
+      name: Service Name
+      type: string
+    - jsonPath: .status.serviceNamespace
+      name: Service Namespace
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ServiceBGPStatus exposes the BGP peers a service is configured
+          to be advertised to, per relevant node.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceBGPStatusSpec defines the desired state of ServiceBGPStatus.
+            type: object
+          status:
+            description: MetalLBServiceBGPStatus defines the observed state of ServiceBGPStatus.
+            properties:
+              node:
+                description: Node indicates the node announcing the service.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              peers:
+                description: |-
+                  Peers indicate the BGP peers for which the service is configured to be advertised to.
+                  The service being actually advertised to a given peer depends on the session state and is not indicated here.
+                items:
                   type: string
-                  x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
-                peers:
-                  description: |-
-                    Peers indicate the BGP peers for which the service is configured to be advertised to.
-                    The service being actually advertised to a given peer depends on the session state and is not indicated here.
-                  items:
-                    type: string
-                  type: array
-                serviceName:
-                  description: ServiceName indicates the service this status represents.
-                  type: string
-                  x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
-                serviceNamespace:
-                  description: ServiceNamespace indicates the namespace of the service.
-                  type: string
-                  x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              serviceName:
+                description: ServiceName indicates the service this status represents.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceNamespace:
+                description: ServiceNamespace indicates the namespace of the service.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicel2statuses.metallb.io
 spec:
   group: metallb.io
@@ -1335,79 +1438,77 @@ spec:
     singular: servicel2status
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.node
-          name: Allocated Node
-          type: string
-        - jsonPath: .status.serviceName
-          name: Service Name
-          type: string
-        - jsonPath: .status.serviceNamespace
-          name: Service Namespace
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description:
-            ServiceL2Status reveals the actual traffic status of loadbalancer
-            services in layer2 mode.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ServiceL2StatusSpec defines the desired state of ServiceL2Status.
-              type: object
-            status:
-              description: MetalLBServiceL2Status defines the observed state of ServiceL2Status.
-              properties:
-                interfaces:
-                  description:
-                    Interfaces indicates the interfaces that receive the
-                    directed traffic
-                  items:
-                    description: InterfaceInfo defines interface info of layer2 announcement.
-                    properties:
-                      name:
-                        description: Name the name of network interface card
-                        type: string
-                    type: object
-                  type: array
-                node:
-                  description: Node indicates the node that receives the directed traffic
-                  type: string
-                  x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
-                serviceName:
-                  description: ServiceName indicates the service this status represents
-                  type: string
-                  x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
-                serviceNamespace:
-                  description: ServiceNamespace indicates the namespace of the service
-                  type: string
-                  x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.node
+      name: Allocated Node
+      type: string
+    - jsonPath: .status.serviceName
+      name: Service Name
+      type: string
+    - jsonPath: .status.serviceNamespace
+      name: Service Namespace
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ServiceL2Status reveals the actual traffic status of loadbalancer
+          services in layer2 mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceL2StatusSpec defines the desired state of ServiceL2Status.
+            type: object
+          status:
+            description: MetalLBServiceL2Status defines the observed state of ServiceL2Status.
+            properties:
+              interfaces:
+                description: Interfaces indicates the interfaces that receive the
+                  directed traffic
+                items:
+                  description: InterfaceInfo defines interface info of layer2 announcement.
+                  properties:
+                    name:
+                      description: Name the name of network interface card
+                      type: string
+                  type: object
+                type: array
+              node:
+                description: Node indicates the node that receives the directed traffic
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceName:
+                description: ServiceName indicates the service this status represents
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceNamespace:
+                description: ServiceNamespace indicates the namespace of the service
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

- Regenerates `addons/metallb/crd.yaml` from the MetalLB **v0.15.3** native manifest (`config/manifests/metallb-native.yaml`).
- Adds the missing `configurationstates.metallb.io` CRD that was introduced in v0.15.3.
- Brings the bundled CRDs in line with the `v0.15.3` controller/speaker images that are already shipped in `metallb.yaml`.

## Context

The previous `crd.yaml` was sourced from v0.15.2 and contained 8 CRDs. The bundled images, however, run v0.15.3 which expects the new status-only `configurationstates.metallb.io` CRD. Without it the resource is missing after `microk8s enable metallb`.

The 8 pre-existing CRD schemas are unchanged between v0.15.2 and v0.15.3 (only the `controller-gen` annotation was bumped `v0.17.2` → `v0.19.0`); the only functional addition is the `configurationstates` CRD. The file now contains all 9 CRDs and validates as well-formed YAML.

Fixes canonical/microk8s#5554
